### PR TITLE
feat: persist closure history and last-closure discovery

### DIFF
--- a/.cursor/rules/typosquat-detection.mdc
+++ b/.cursor/rules/typosquat-detection.mdc
@@ -17,6 +17,8 @@ This is a **multi-phase orchestrator task** that produces `FindingType.TYPOSQUAT
 
 **WHOIS persistence (API database):** Runner/worker payloads still send flat `whois_*` fields on typosquat findings. The API stores registration/WHOIS on **`typosquat_apex_domains`** (one row per `(program_id, registrable apex_domain)`), linked via `typosquat_domains.apex_typosquat_domain_id`. Listing and detail responses **merge** apex WHOIS onto each finding so JSON shape stays the same for clients.
 
+**Closure history (`typosquat_domains.closure_events`):** JSONB array, append-only. Each element: `to_status` (`resolved` | `dismissed`), `closed_at` (ISO string), `closed_by_user_id`, optional `source_action_log_id` (backfill from `action_logs`). **`last_closure_at`** (column, UTC naive) duplicates the latest `closed_at` for indexing/sorting; backfilled from the last JSON element in migrations; updated on each new closure (not cleared on reopen). `TyposquatFindingsRepository.update_typosquat_domain` appends on transitions into `resolved`/`dismissed` when the status actually changes; sets `fixed_at` on resolve and clears it on reopen from a terminal status. Clients must not send `closure_events` or `last_closure_at` in update payloads (ignored). API exposes `last_closure_at`, `last_closure_to_status`, `last_closed_by_user_id` (date from column when present).
+
 ## Architecture
 
 ```

--- a/kubernetes/base/postgresql/schema.sql
+++ b/kubernetes/base/postgresql/schema.sql
@@ -1105,6 +1105,8 @@ CREATE TABLE public.typosquat_domains (
     auto_resolve boolean DEFAULT false,
     ai_analysis jsonb,
     ai_analyzed_at timestamp without time zone,
+    closure_events jsonb DEFAULT '[]'::jsonb NOT NULL,
+    last_closure_at timestamp without time zone,
     apex_typosquat_domain_id uuid NOT NULL
 );
 
@@ -1205,6 +1207,20 @@ COMMENT ON COLUMN public.typosquat_domains.ai_analysis IS 'Structured AI analysi
 --
 
 COMMENT ON COLUMN public.typosquat_domains.ai_analyzed_at IS 'Timestamp of last AI analysis run';
+
+
+--
+-- Name: COLUMN typosquat_domains.closure_events; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.typosquat_domains.closure_events IS 'Append-only array of {to_status, closed_at, closed_by_user_id, source_action_log_id?} for resolved/dismissed transitions';
+
+
+--
+-- Name: COLUMN typosquat_domains.last_closure_at; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.typosquat_domains.last_closure_at IS 'UTC time of the most recent resolved/dismissed closure';
 
 
 --
@@ -3197,6 +3213,13 @@ CREATE INDEX ix_typosquat_domains_domain_registered ON public.typosquat_domains 
 --
 
 CREATE INDEX ix_typosquat_domains_fixed_at ON public.typosquat_domains USING btree (fixed_at);
+
+
+--
+-- Name: ix_typosquat_domains_last_closure_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_typosquat_domains_last_closure_at ON public.typosquat_domains USING btree (last_closure_at);
 
 
 --

--- a/src/api/app/models/postgres.py
+++ b/src/api/app/models/postgres.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Text, DateTime, Boolean, ForeignKey, ARRAY, BigInteger, SmallInteger, UniqueConstraint, LargeBinary, func
+from sqlalchemy import Column, Integer, String, Text, DateTime, Boolean, ForeignKey, ARRAY, BigInteger, SmallInteger, UniqueConstraint, LargeBinary, func, text
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship
 from sqlalchemy.dialects.postgresql import UUID, INET, JSONB
@@ -591,6 +591,11 @@ class TyposquatDomain(Base):
     # AI analysis
     ai_analysis = Column(JSONB, nullable=True)
     ai_analyzed_at = Column(DateTime, nullable=True)
+
+    # Append-only closure history: {to_status, closed_at, closed_by_user_id, source_action_log_id?}[]
+    closure_events = Column(JSONB, nullable=False, server_default=text("'[]'::jsonb"))
+    # Denormalized: same instant as last closure_events[].closed_at (UTC naive)
+    last_closure_at = Column(DateTime, nullable=True, index=True)
 
     # Relationships
     program = relationship("Program", back_populates="typosquat_findings")

--- a/src/api/app/repository/typosquat_findings_repo.py
+++ b/src/api/app/repository/typosquat_findings_repo.py
@@ -48,6 +48,63 @@ _WHOIS_PAYLOAD_KEYS = (
     "whois_admin_email",
 )
 
+_TERMINAL_CLOSURE_STATUSES = frozenset(("resolved", "dismissed"))
+
+
+def _last_closure_summary(
+    closure_events: Any,
+    last_closure_at_column: Any = None,
+) -> Dict[str, Any]:
+    """Derive list-friendly fields; prefer persisted last_closure_at for the date."""
+    out: Dict[str, Any] = {
+        "last_closure_at": None,
+        "last_closure_to_status": None,
+        "last_closed_by_user_id": None,
+    }
+    if last_closure_at_column is not None:
+        if isinstance(last_closure_at_column, datetime):
+            out["last_closure_at"] = last_closure_at_column.isoformat() + "Z"
+        else:
+            out["last_closure_at"] = str(last_closure_at_column)
+    if not closure_events or not isinstance(closure_events, list):
+        return out
+    last = closure_events[-1]
+    if not isinstance(last, dict):
+        return out
+    if out["last_closure_at"] is None:
+        out["last_closure_at"] = last.get("closed_at")
+    out["last_closure_to_status"] = last.get("to_status")
+    out["last_closed_by_user_id"] = last.get("closed_by_user_id")
+    return out
+
+
+def _closure_events_for_api(db, events: Any) -> List[Dict[str, Any]]:
+    """Copy closure event dicts and attach closed_by_username when user exists."""
+    if not events or not isinstance(events, list):
+        return []
+    user_ids_set = set()
+    for e in events:
+        if isinstance(e, dict) and e.get("closed_by_user_id"):
+            user_ids_set.add(str(e["closed_by_user_id"]))
+    id_to_name: Dict[str, Optional[str]] = {}
+    if user_ids_set:
+        try:
+            uid_cast = [uuid.UUID(u) for u in user_ids_set]
+        except ValueError:
+            uid_cast = []
+        if uid_cast:
+            for row in db.query(User.id, User.username).filter(User.id.in_(uid_cast)).all():
+                id_to_name[str(row.id)] = row.username
+    out: List[Dict[str, Any]] = []
+    for e in events:
+        if not isinstance(e, dict):
+            continue
+        row = dict(e)
+        cid = row.get("closed_by_user_id")
+        row["closed_by_username"] = id_to_name.get(str(cid)) if cid else None
+        out.append(row)
+    return out
+
 
 class TyposquatFindingsRepository(ProgramAccessMixin):
     """PostgreSQL repository for findings operations"""
@@ -970,6 +1027,9 @@ class TyposquatFindingsRepository(ProgramAccessMixin):
                     # AI analysis
                     'ai_analysis': typosquat.ai_analysis,
                     'ai_analyzed_at': typosquat.ai_analyzed_at.isoformat() if typosquat.ai_analyzed_at else None,
+                    # Closure history (resolved / dismissed), with usernames
+                    'closure_events': _closure_events_for_api(db, typosquat.closure_events),
+                    **_last_closure_summary(typosquat.closure_events, typosquat.last_closure_at),
                 }
                 
             except Exception as e:
@@ -1174,6 +1234,7 @@ class TyposquatFindingsRepository(ProgramAccessMixin):
                         'parked_detection_reasons': typosquat.parked_detection_reasons,
                         'ai_analysis': typosquat.ai_analysis,
                         'ai_analyzed_at': typosquat.ai_analyzed_at.isoformat() if typosquat.ai_analyzed_at else None,
+                        **_last_closure_summary(typosquat.closure_events, typosquat.last_closure_at),
                     })
                 
                 return result
@@ -1240,6 +1301,8 @@ class TyposquatFindingsRepository(ProgramAccessMixin):
         created_at_to: Optional[datetime] = None,
         updated_at_from: Optional[datetime] = None,
         updated_at_to: Optional[datetime] = None,
+        last_closure_at_from: Optional[datetime] = None,
+        last_closure_at_to: Optional[datetime] = None,
         programs: Optional[List[str]] = None,
         sort_by: str = "updated_at",
         sort_dir: str = "desc",
@@ -1284,6 +1347,8 @@ class TyposquatFindingsRepository(ProgramAccessMixin):
                         TyposquatDomain.auto_resolve.label("auto_resolve"),
                         TyposquatDomain.ai_analysis.label("ai_analysis"),
                         TyposquatDomain.ai_analyzed_at.label("ai_analyzed_at"),
+                        TyposquatDomain.closure_events.label("closure_events"),
+                        TyposquatDomain.last_closure_at.label("last_closure_at"),
                     )
                     .select_from(TyposquatDomain)
                     .join(
@@ -1489,6 +1554,10 @@ class TyposquatFindingsRepository(ProgramAccessMixin):
                     base_query = base_query.filter(TyposquatDomain.updated_at >= updated_at_from)
                 if updated_at_to is not None:
                     base_query = base_query.filter(TyposquatDomain.updated_at <= updated_at_to)
+                if last_closure_at_from is not None:
+                    base_query = base_query.filter(TyposquatDomain.last_closure_at >= last_closure_at_from)
+                if last_closure_at_to is not None:
+                    base_query = base_query.filter(TyposquatDomain.last_closure_at <= last_closure_at_to)
 
                 # Protected domain similarity filter
                 # Filter by similarity to a specific protected domain with optional minimum percentage
@@ -1726,6 +1795,10 @@ class TyposquatFindingsRepository(ProgramAccessMixin):
                     count_query = count_query.filter(TyposquatDomain.updated_at >= updated_at_from)
                 if updated_at_to is not None:
                     count_query = count_query.filter(TyposquatDomain.updated_at <= updated_at_to)
+                if last_closure_at_from is not None:
+                    count_query = count_query.filter(TyposquatDomain.last_closure_at >= last_closure_at_from)
+                if last_closure_at_to is not None:
+                    count_query = count_query.filter(TyposquatDomain.last_closure_at <= last_closure_at_to)
 
                 # Protected domain similarity filter for count query
                 if similarity_protected_domain or min_similarity_percent is not None:
@@ -1795,6 +1868,12 @@ class TyposquatFindingsRepository(ProgramAccessMixin):
                         else_=5
                     )
                     base_query = base_query.order_by(sort_dir_func(severity))
+                elif sort_by == "last_closure_at":
+                    lc = TyposquatDomain.last_closure_at
+                    if sort_dir == "asc":
+                        base_query = base_query.order_by(asc(lc).nullsfirst())
+                    else:
+                        base_query = base_query.order_by(desc(lc).nullslast())
                 else:
                     sort_col = sort_map.get(sort_by, TyposquatDomain.updated_at)
                     base_query = base_query.order_by(sort_dir_func(sort_col))
@@ -1831,6 +1910,10 @@ class TyposquatFindingsRepository(ProgramAccessMixin):
                         "auto_resolve": getattr(row, 'auto_resolve', False),
                         "ai_analysis": getattr(row, 'ai_analysis', None),
                         "ai_analyzed_at": row.ai_analyzed_at.isoformat() if getattr(row, 'ai_analyzed_at', None) else None,
+                        **_last_closure_summary(
+                            getattr(row, "closure_events", None),
+                            getattr(row, "last_closure_at", None),
+                        ),
                     })
 
                 return {"items": items, "total_count": total_count}
@@ -2287,11 +2370,16 @@ class TyposquatFindingsRepository(ProgramAccessMixin):
                     # Force the object to match the database state
                     typosquat.action_taken = fresh_query
 
+                prev_status = typosquat.status or "new"
+
                 whois_payload = TyposquatFindingsRepository._whois_subset_from_typosquat_data(
                     update_data
                 )
                 for k in list(whois_payload.keys()):
                     update_data.pop(k, None)
+                # Client must not overwrite append-only closure history
+                update_data.pop("closure_events", None)
+                update_data.pop("last_closure_at", None)
                 if whois_payload:
                     apex_name = extract_apex_domain(typosquat.typo_domain)
                     apex = TyposquatFindingsRepository.find_or_create_typosquat_apex_in_session(
@@ -2427,6 +2515,28 @@ class TyposquatFindingsRepository(ProgramAccessMixin):
                     old_actions = list(typosquat.action_taken or [])  # Create a copy to avoid reference issues
                     typosquat.action_taken = action_taken_for_database
                     logger.info(f"Updated action_taken for domain {domain_id}: {old_actions} -> {action_taken_for_database}")
+
+                # Append-only closure history; sync fixed_at for legacy views (e.g. security_summary)
+                if status_updated and new_status:
+                    ns = new_status
+                    ps = prev_status or "new"
+                    if ns in _TERMINAL_CLOSURE_STATUSES and ps != ns:
+                        closed_at_naive = datetime.utcnow()
+                        closed_at_str = closed_at_naive.isoformat() + "Z"
+                        existing_ev = typosquat.closure_events
+                        if existing_ev is None or not isinstance(existing_ev, list):
+                            existing_ev = []
+                        ev: Dict[str, Any] = {
+                            "to_status": ns,
+                            "closed_at": closed_at_str,
+                            "closed_by_user_id": typosquat.assigned_to or None,
+                        }
+                        typosquat.closure_events = list(existing_ev) + [ev]
+                        typosquat.last_closure_at = closed_at_naive
+                        if ns == "resolved":
+                            typosquat.fixed_at = closed_at_naive
+                    elif ns in ("new", "inprogress") and ps in _TERMINAL_CLOSURE_STATUSES:
+                        typosquat.fixed_at = None
 
                 typosquat.updated_at = datetime.utcnow()
                 logger.debug(f"Committing database changes for domain {domain_id}")

--- a/src/api/app/routes/typosquat_findings.py
+++ b/src/api/app/routes/typosquat_findings.py
@@ -348,6 +348,8 @@ class TyposquatSearchRequest(BaseModel):
     created_at_to: Optional[datetime] = Field(None, description="Inclusive upper bound on created_at")
     updated_at_from: Optional[datetime] = Field(None, description="Inclusive lower bound on updated_at")
     updated_at_to: Optional[datetime] = Field(None, description="Inclusive upper bound on updated_at")
+    last_closure_at_from: Optional[datetime] = Field(None, description="Inclusive lower bound on last_closure_at")
+    last_closure_at_to: Optional[datetime] = Field(None, description="Inclusive upper bound on last_closure_at")
     program: Optional[Union[List[str], str]] = Field(None, description="Restrict to program(s) within user's access scope")
     sort_by: Optional[str] = Field("updated_at")
     sort_dir: Optional[str] = Field("desc")
@@ -728,6 +730,8 @@ async def search_typosquat_typed(request: TyposquatSearchRequest, current_user: 
             created_at_to=request.created_at_to,
             updated_at_from=request.updated_at_from,
             updated_at_to=request.updated_at_to,
+            last_closure_at_from=request.last_closure_at_from,
+            last_closure_at_to=request.last_closure_at_to,
             programs=programs,
             sort_by=request.sort_by or "updated_at",
             sort_dir=request.sort_dir or "desc",

--- a/src/frontend/src/pages/findings/TyposquatFindingDetail.js
+++ b/src/frontend/src/pages/findings/TyposquatFindingDetail.js
@@ -1547,6 +1547,49 @@ function TyposquatFindingDetail() {
         </Card.Body>
       </Card>
 
+      {/* Resolved / dismissed closure history (persisted; survives reopen) */}
+      {Array.isArray(finding?.closure_events) && finding.closure_events.length > 0 && (
+        <Card className="mb-4">
+          <Card.Header>
+            <h6 className="mb-0">Closure history</h6>
+          </Card.Header>
+          <Card.Body className="p-0">
+            <Table responsive hover className="mb-0" size="sm">
+              <thead className="table-light">
+                <tr>
+                  <th>Closed at</th>
+                  <th>Outcome</th>
+                  <th>Closed by</th>
+                </tr>
+              </thead>
+              <tbody>
+                {finding.closure_events.map((ev, idx) => (
+                  <tr key={ev.source_action_log_id || `${idx}-${ev.closed_at}`}>
+                    <td>{ev.closed_at ? formatDate(ev.closed_at) : '—'}</td>
+                    <td>
+                      {ev.to_status ? (
+                        <Badge bg={getStatusBadgeVariant(ev.to_status)}>
+                          {formatStatus(ev.to_status)}
+                        </Badge>
+                      ) : (
+                        '—'
+                      )}
+                    </td>
+                    <td>
+                      {ev.closed_by_username
+                        ? ev.closed_by_username
+                        : ev.closed_by_user_id
+                          ? formatAssignedTo(ev.closed_by_user_id)
+                          : '—'}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </Table>
+          </Card.Body>
+        </Card>
+      )}
+
       {/* History Section */}
       <Card className="mb-4">
         <Card.Header>

--- a/src/frontend/src/pages/findings/TyposquatFindings.js
+++ b/src/frontend/src/pages/findings/TyposquatFindings.js
@@ -137,7 +137,9 @@ function TyposquatFindings() {
     created_at_from: searchParams.get('created_at_from') || '',
     created_at_to: searchParams.get('created_at_to') || '',
     updated_at_from: searchParams.get('updated_at_from') || '',
-    updated_at_to: searchParams.get('updated_at_to') || ''
+    updated_at_to: searchParams.get('updated_at_to') || '',
+    last_closure_at_from: searchParams.get('last_closure_at_from') || '',
+    last_closure_at_to: searchParams.get('last_closure_at_to') || ''
   });
   
   // Sort state
@@ -367,6 +369,8 @@ function TyposquatFindings() {
       created_at_to: dayEndUtc(filters.created_at_to),
       updated_at_from: dayStartUtc(filters.updated_at_from),
       updated_at_to: dayEndUtc(filters.updated_at_to),
+      last_closure_at_from: dayStartUtc(filters.last_closure_at_from),
+      last_closure_at_to: dayEndUtc(filters.last_closure_at_to),
       program: selectedProgram || undefined,
       sort_by: sortField,
       sort_dir: sortDirection,
@@ -1773,7 +1777,7 @@ function TyposquatFindings() {
                 <hr className="my-3" />
                 <h6 className="text-secondary text-uppercase small fw-semibold mb-0">Date range</h6>
                 <Row className="g-3 mt-2">
-                  <Col md={6}>
+                  <Col md={4}>
                     <Form.Group className="mb-0">
                       <Form.Label>Created at</Form.Label>
                       <div className="d-flex flex-wrap align-items-center gap-2">
@@ -1793,7 +1797,7 @@ function TyposquatFindings() {
                       </div>
                     </Form.Group>
                   </Col>
-                  <Col md={6}>
+                  <Col md={4}>
                     <Form.Group className="mb-0">
                       <Form.Label>Updated at</Form.Label>
                       <div className="d-flex flex-wrap align-items-center gap-2">
@@ -1811,6 +1815,27 @@ function TyposquatFindings() {
                           aria-label="Updated to"
                         />
                       </div>
+                    </Form.Group>
+                  </Col>
+                  <Col md={4}>
+                    <Form.Group className="mb-0">
+                      <Form.Label>Last closure (resolved / dismissed)</Form.Label>
+                      <div className="d-flex flex-wrap align-items-center gap-2">
+                        <Form.Control
+                          type="date"
+                          value={filters.last_closure_at_from}
+                          onChange={(e) => handleFilterChange('last_closure_at_from', e.target.value)}
+                          aria-label="Last closure from"
+                        />
+                        <span className="text-muted small">to</span>
+                        <Form.Control
+                          type="date"
+                          value={filters.last_closure_at_to}
+                          onChange={(e) => handleFilterChange('last_closure_at_to', e.target.value)}
+                          aria-label="Last closure to"
+                        />
+                      </div>
+                      <Form.Text className="text-muted">UTC day range on last resolve/dismiss time.</Form.Text>
                     </Form.Group>
                   </Col>
                 </Row>
@@ -2023,7 +2048,9 @@ function TyposquatFindings() {
                         created_at_from: '',
                         created_at_to: '',
                         updated_at_from: '',
-                        updated_at_to: ''
+                        updated_at_to: '',
+                        last_closure_at_from: '',
+                        last_closure_at_to: ''
                       });
                     }}>
                       Clear
@@ -2070,7 +2097,9 @@ function TyposquatFindings() {
                 created_at_from: '',
                 created_at_to: '',
                 updated_at_from: '',
-                updated_at_to: ''
+                updated_at_to: '',
+                last_closure_at_from: '',
+                last_closure_at_to: ''
               });
               setCurrentPage(1);
             }}>Reset filters</Button>
@@ -2206,6 +2235,9 @@ function TyposquatFindings() {
                       >
                         Last Updated {getSortIcon('updated_at')}
                       </th>
+                    <th style={{ cursor: 'pointer' }} onClick={() => handleSort('last_closure_at')}>
+                      Last closure {getSortIcon('last_closure_at')}
+                    </th>
                   </tr>
                 </thead>
                 <tbody>
@@ -2419,6 +2451,11 @@ function TyposquatFindings() {
                         </td>
                         <td className="text-muted">
                           {formatDate(finding.updated_at, 'MMM dd, yyyy HH:mm:ss')}
+                        </td>
+                        <td className="text-muted">
+                          {finding.last_closure_at
+                            ? formatDate(finding.last_closure_at, 'MMM dd, yyyy HH:mm:ss')
+                            : '—'}
                         </td>
                         {/* <td>
                           <div className="d-flex gap-1">

--- a/src/migrations/V0.0.2__Typosquat_closure_events_jsonb.sql
+++ b/src/migrations/V0.0.2__Typosquat_closure_events_jsonb.sql
@@ -1,0 +1,44 @@
+-- Migration: Append-only closure history (resolved/dismissed) on typosquat_domains
+-- Version: 0.0.2
+
+-- UP MIGRATION
+ALTER TABLE typosquat_domains
+    ADD COLUMN IF NOT EXISTS closure_events jsonb NOT NULL DEFAULT '[]'::jsonb;
+
+COMMENT ON COLUMN typosquat_domains.closure_events IS 'Ordered array of closure events: to_status, closed_at, closed_by_user_id, optional source_action_log_id';
+
+-- Backfill from action_logs (idempotent: only rows still empty)
+UPDATE typosquat_domains td
+SET closure_events = s.arr
+FROM (
+    SELECT
+        x.entity_id,
+        jsonb_agg(x.elem ORDER BY x.sort_ts) AS arr
+    FROM (
+        SELECT
+            al.entity_id,
+            al.created_at AS sort_ts,
+            jsonb_build_object(
+                'to_status', al.new_value->>'status',
+                'closed_at', to_char((al.created_at AT TIME ZONE 'UTC'), 'YYYY-MM-DD"T"HH24:MI:SS.MS') || 'Z',
+                'closed_by_user_id',
+                CASE
+                    WHEN (al.metadata->>'assigned_to') ~ '^[0-9a-fA-F-]{36}$'
+                    THEN al.metadata->>'assigned_to'
+                    ELSE al.user_id::text
+                END,
+                'source_action_log_id', al.id::text
+            ) AS elem
+        FROM action_logs al
+        WHERE al.entity_type = 'typosquat_finding'
+          AND al.action_type = 'status_change'
+          AND COALESCE(al.new_value->>'status', '') IN ('resolved', 'dismissed')
+          AND al.old_value->>'status' IS DISTINCT FROM al.new_value->>'status'
+    ) x
+    GROUP BY x.entity_id
+) s
+WHERE td.id::text = s.entity_id
+  AND jsonb_array_length(td.closure_events) = 0;
+
+-- DOWN MIGRATION
+-- ALTER TABLE typosquat_domains DROP COLUMN IF EXISTS closure_events;

--- a/src/migrations/V0.0.3__Add_last_closure_at_typosquat_domains.sql
+++ b/src/migrations/V0.0.3__Add_last_closure_at_typosquat_domains.sql
@@ -1,0 +1,26 @@
+-- Migration: Denormalized last closure timestamp on typosquat_domains
+-- Version: 0.0.3
+
+-- UP MIGRATION
+ALTER TABLE typosquat_domains
+    ADD COLUMN IF NOT EXISTS last_closure_at timestamp without time zone;
+
+COMMENT ON COLUMN typosquat_domains.last_closure_at IS 'UTC time of the most recent resolved/dismissed closure (matches last closure_events[].closed_at)';
+
+CREATE INDEX IF NOT EXISTS ix_typosquat_domains_last_closure_at
+    ON typosquat_domains (last_closure_at);
+
+-- Backfill from last closure_events element (if any)
+UPDATE typosquat_domains
+SET last_closure_at = (
+    ((closure_events #>> '{-1,closed_at}'))::timestamptz AT TIME ZONE 'UTC'
+)
+WHERE jsonb_array_length(closure_events) > 0
+  AND (closure_events->-1) ? 'closed_at'
+  AND (closure_events #>> '{-1,closed_at}') IS NOT NULL
+  AND trim(closure_events #>> '{-1,closed_at}') <> ''
+  AND last_closure_at IS NULL;
+
+-- DOWN MIGRATION
+-- DROP INDEX IF EXISTS ix_typosquat_domains_last_closure_at;
+-- ALTER TABLE typosquat_domains DROP COLUMN IF EXISTS last_closure_at;


### PR DESCRIPTION
Add closure_events JSONB (backfilled from status_change action logs) and last_closure_at for indexed filtering and sorting. Repository appends on resolve/dismiss transitions and keeps fixed_at in sync; clients cannot overwrite persisted closure fields via updates.

Expose closure_events (with usernames) on detail and last-closure summary fields plus last_closure_at range filters on search. Frontend shows a closure history table on the detail page and a sortable Last closure column with date-only display on the list.

Made-with: Cursor