### PR TITLE
refactor(frontend): set distinct browser tab titles per route

### DIFF
--- a/src/frontend/src/components/Login.js
+++ b/src/frontend/src/components/Login.js
@@ -3,11 +3,13 @@ import { Container, Row, Col, Card, Form, Button, Alert, Spinner } from 'react-b
 import { useAuth } from '../contexts/AuthContext';
 import { Navigate, useLocation } from 'react-router-dom';
 import { useTheme } from '../contexts/ThemeContext';
+import { usePageTitle, formatPageTitle } from '../hooks/usePageTitle';
 
 const BANNER_DARK = `${process.env.PUBLIC_URL}/banner_dark_transparent.png`;
 const BANNER_LIGHT = `${process.env.PUBLIC_URL}/banner_light_transparent.png`;
 
 function Login() {
+  usePageTitle(formatPageTitle('Sign In'));
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [validated, setValidated] = useState(false);

--- a/src/frontend/src/hooks/usePageTitle.js
+++ b/src/frontend/src/hooks/usePageTitle.js
@@ -1,0 +1,43 @@
+import { useEffect } from 'react';
+
+const BRAND = 'ReconHawx';
+const SEP = ' · ';
+
+/**
+ * Join non-empty parts with middle separator, then append brand.
+ * @param {...string|null|undefined} parts
+ * @returns {string}
+ */
+export function formatPageTitle(...parts) {
+  const head = parts
+    .map((p) => (p == null ? '' : String(p).trim()))
+    .filter(Boolean);
+  if (head.length === 0) return BRAND;
+  return `${head.join(SEP)}${SEP}${BRAND}`;
+}
+
+/**
+ * Shorten long strings for browser tabs (middle ellipsis).
+ * @param {string} str
+ * @param {number} maxLen
+ * @returns {string}
+ */
+export function truncateTitle(str, maxLen = 72) {
+  if (str == null || str === '') return '';
+  const s = String(str);
+  if (s.length <= maxLen) return s;
+  const keep = maxLen - 1;
+  const left = Math.ceil(keep / 2);
+  const right = Math.floor(keep / 2);
+  return `${s.slice(0, left)}…${s.slice(s.length - right)}`;
+}
+
+/**
+ * Sync document.title when titleString changes.
+ * @param {string} titleString
+ */
+export function usePageTitle(titleString) {
+  useEffect(() => {
+    document.title = titleString;
+  }, [titleString]);
+}

--- a/src/frontend/src/pages/ChangePassword.js
+++ b/src/frontend/src/pages/ChangePassword.js
@@ -3,8 +3,10 @@ import { Container, Row, Col, Card, Form, Button, Alert } from 'react-bootstrap'
 import { useAuth } from '../contexts/AuthContext';
 import { useNavigate } from 'react-router-dom';
 import apiObject from '../services/api';
+import { usePageTitle, formatPageTitle } from '../hooks/usePageTitle';
 
 function ChangePassword() {
+  usePageTitle(formatPageTitle('Change Password'));
   const { user, updateUser } = useAuth();
   const navigate = useNavigate();
   const [currentPassword, setCurrentPassword] = useState('');

--- a/src/frontend/src/pages/Dashboard.js
+++ b/src/frontend/src/pages/Dashboard.js
@@ -3,6 +3,7 @@ import { Container, Row, Col, Card, Alert, Spinner, Badge, Button } from 'react-
 import { Link } from 'react-router-dom';
 import { useProgramFilter } from '../contexts/ProgramFilterContext';
 import { workflowAPI, commonStatsAPI } from '../services/api';
+import { usePageTitle, formatPageTitle } from '../hooks/usePageTitle';
 // Utility function to calculate age from created_at timestamp
 const getAgeFromDate = (createdAt) => {
   if (!createdAt) return 'N/A';
@@ -43,6 +44,7 @@ styleSheet.innerText = styles;
 document.head.appendChild(styleSheet);
 
 function Dashboard() {
+  usePageTitle(formatPageTitle('Dashboard'));
   const { selectedProgram } = useProgramFilter();
   const [stats, setStats] = useState({
     subdomains: 0, apexDomains: 0, ips: 0, services: 0, urls: 0, certificates: 0,

--- a/src/frontend/src/pages/admin/ApiTokens.js
+++ b/src/frontend/src/pages/admin/ApiTokens.js
@@ -2,7 +2,10 @@ import React from 'react';
 import { Container, Row, Col } from 'react-bootstrap';
 import ApiTokenManagement from '../../components/ApiTokenManagement';
 import ApiDocumentation from '../../components/ApiDocumentation';
+import { usePageTitle, formatPageTitle } from '../../hooks/usePageTitle';
+
 function ApiTokens() {
+  usePageTitle(formatPageTitle('API Tokens'));
   return (
     <Container fluid className="mt-4">
       <Row>

--- a/src/frontend/src/pages/admin/CTMonitor.js
+++ b/src/frontend/src/pages/admin/CTMonitor.js
@@ -14,8 +14,10 @@ import {
 } from 'react-bootstrap';
 import { Link } from 'react-router-dom';
 import { ctMonitorAPI } from '../../services/api';
+import { usePageTitle, formatPageTitle } from '../../hooks/usePageTitle';
 
 function CTMonitor() {
+  usePageTitle(formatPageTitle('CT Monitor'));
   const [status, setStatus] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');

--- a/src/frontend/src/pages/admin/EventHandlerConfig.js
+++ b/src/frontend/src/pages/admin/EventHandlerConfig.js
@@ -11,8 +11,10 @@ import {
 } from 'react-bootstrap';
 import { adminAPI } from '../../services/api';
 import EventHandlerForm from '../../components/EventHandlerForm';
+import { usePageTitle, formatPageTitle } from '../../hooks/usePageTitle';
 
 function EventHandlerConfig() {
+  usePageTitle(formatPageTitle('Event Handler Config'));
   const [handlers, setHandlers] = useState([]);
   const [systemHandlers, setSystemHandlers] = useState([]);
   const [loading, setLoading] = useState(true);

--- a/src/frontend/src/pages/admin/EventStats.js
+++ b/src/frontend/src/pages/admin/EventStats.js
@@ -16,8 +16,10 @@ import {
   Modal
 } from 'react-bootstrap';
 import { adminAPI } from '../../services/api';
+import { usePageTitle, formatPageTitle } from '../../hooks/usePageTitle';
 
 function EventStats() {
+  usePageTitle(formatPageTitle('Event Stats'));
   const [stats, setStats] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');

--- a/src/frontend/src/pages/admin/JobManagement.js
+++ b/src/frontend/src/pages/admin/JobManagement.js
@@ -16,8 +16,10 @@ import {
 } from 'react-bootstrap';
 import { jobAPI } from '../../services/api';
 import { formatDate } from '../../utils/dateUtils';
+import { usePageTitle, formatPageTitle } from '../../hooks/usePageTitle';
 
 function JobManagement() {
+  usePageTitle(formatPageTitle('Job Management'));
   const [jobs, setJobs] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');

--- a/src/frontend/src/pages/admin/NucleiTemplates.js
+++ b/src/frontend/src/pages/admin/NucleiTemplates.js
@@ -17,8 +17,10 @@ import {
   Tab
 } from 'react-bootstrap';
 import { nucleiTemplatesAPI } from '../../services/api';
+import { usePageTitle, formatPageTitle } from '../../hooks/usePageTitle';
 
 function NucleiTemplates() {
+  usePageTitle(formatPageTitle('Nuclei Templates'));
   const [templates, setTemplates] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);

--- a/src/frontend/src/pages/admin/SocialMediaCredentials.js
+++ b/src/frontend/src/pages/admin/SocialMediaCredentials.js
@@ -1,8 +1,10 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { Container, Card, Table, Button, Modal, Form, Alert, Spinner, Badge, Row, Col } from 'react-bootstrap';
 import { socialMediaCredentialsAPI } from '../../services/api';
+import { usePageTitle, formatPageTitle } from '../../hooks/usePageTitle';
 
 function SocialMediaCredentials() {
+  usePageTitle(formatPageTitle('Social Media Credentials'));
   const [credentials, setCredentials] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);

--- a/src/frontend/src/pages/admin/SystemMaintenance.js
+++ b/src/frontend/src/pages/admin/SystemMaintenance.js
@@ -13,6 +13,7 @@ import {
   Modal
 } from 'react-bootstrap';
 import { adminAPI } from '../../services/api';
+import { usePageTitle, formatPageTitle } from '../../hooks/usePageTitle';
 
 import './SystemMaintenance.css';
 
@@ -218,6 +219,8 @@ function SystemMaintenance() {
       /* non-fatal */
     }
   }, []);
+
+  usePageTitle(formatPageTitle('System Maintenance'));
 
   useEffect(() => {
     loadStatus();

--- a/src/frontend/src/pages/admin/SystemSettings.js
+++ b/src/frontend/src/pages/admin/SystemSettings.js
@@ -16,6 +16,7 @@ import {
 } from 'react-bootstrap';
 import { adminAPI } from '../../services/api';
 import { formatDate } from '../../utils/dateUtils';
+import { usePageTitle, formatPageTitle } from '../../hooks/usePageTitle';
 
 // Add Font Awesome CSS if not already loaded
 const loadFontAwesome = () => {
@@ -28,6 +29,7 @@ const loadFontAwesome = () => {
 };
 
 function SystemSettings() {
+  usePageTitle(formatPageTitle('System Settings'));
   const [reconTasks, setReconTasks] = useState([]);
   const [awsCredentials, setAwsCredentials] = useState([]);
   const [loading, setLoading] = useState(true);

--- a/src/frontend/src/pages/admin/SystemStatus.js
+++ b/src/frontend/src/pages/admin/SystemStatus.js
@@ -11,6 +11,7 @@ import {
   Button
 } from 'react-bootstrap';
 import { adminAPI } from '../../services/api';
+import { usePageTitle, formatPageTitle } from '../../hooks/usePageTitle';
 
 const STATUS_VARIANT = {
   available: 'success',
@@ -19,6 +20,7 @@ const STATUS_VARIANT = {
 };
 
 function SystemStatus() {
+  usePageTitle(formatPageTitle('System Status'));
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');

--- a/src/frontend/src/pages/admin/UserManagement.js
+++ b/src/frontend/src/pages/admin/UserManagement.js
@@ -15,8 +15,10 @@ import {
 } from 'react-bootstrap';
 import { userManagementAPI, programAPI } from '../../services/api';
 import ApiTokenManagement from '../../components/ApiTokenManagement';
+import { usePageTitle, formatPageTitle } from '../../hooks/usePageTitle';
 
 function UserManagement() {
+  usePageTitle(formatPageTitle('User Management'));
   const [users, setUsers] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');

--- a/src/frontend/src/pages/admin/Wordlists.js
+++ b/src/frontend/src/pages/admin/Wordlists.js
@@ -18,8 +18,10 @@ import {
 import { wordlistsAPI } from '../../services/api';
 import { formatDate } from '../../utils/dateUtils';
 import { useProgramFilter } from '../../contexts/ProgramFilterContext';
+import { usePageTitle, formatPageTitle } from '../../hooks/usePageTitle';
 
 function Wordlists() {
+  usePageTitle(formatPageTitle('Wordlists'));
   const { programs, selectedProgram } = useProgramFilter();
   const [wordlists, setWordlists] = useState([]);
   const [loading, setLoading] = useState(true);

--- a/src/frontend/src/pages/assets/ApexDomainDetail.js
+++ b/src/frontend/src/pages/assets/ApexDomainDetail.js
@@ -4,6 +4,7 @@ import { Container, Row, Col, Card, Badge, Button, Spinner, Alert, Table, Collap
 import { domainAPI, apexDomainAPI } from '../../services/api';
 import NotesSection from '../../components/NotesSection';
 import { formatDate } from '../../utils/dateUtils';
+import { usePageTitle, formatPageTitle } from '../../hooks/usePageTitle';
 
 function ApexDomainDetail() {
   const { apexDomainName } = useParams();
@@ -18,6 +19,7 @@ function ApexDomainDetail() {
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [deleting, setDeleting] = useState(false);
 
+  usePageTitle(formatPageTitle(apexDomain?.name, 'Apex Domain'));
 
   useEffect(() => {
     const fetchApexDomain = async () => {

--- a/src/frontend/src/pages/assets/ApexDomains.js
+++ b/src/frontend/src/pages/assets/ApexDomains.js
@@ -4,8 +4,10 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { apexDomainAPI, programAPI } from '../../services/api';
 import { useProgramFilter } from '../../contexts/ProgramFilterContext';
 import { formatDate } from '../../utils/dateUtils';
+import { usePageTitle, formatPageTitle } from '../../hooks/usePageTitle';
 
 function ApexDomains() {
+  usePageTitle(formatPageTitle('Apex Domains'));
   const navigate = useNavigate();
   const location = useLocation();
   const { selectedProgram, setSelectedProgram } = useProgramFilter();

--- a/src/frontend/src/pages/assets/CertificateDetail.js
+++ b/src/frontend/src/pages/assets/CertificateDetail.js
@@ -4,6 +4,7 @@ import { Container, Row, Col, Card, Badge, Button, Spinner, Alert, Table, Collap
 import { certificateAPI } from '../../services/api';
 import NotesSection from '../../components/NotesSection';
 import { formatDate, isExpired, isExpiringSoon } from '../../utils/dateUtils';
+import { usePageTitle, formatPageTitle, truncateTitle } from '../../hooks/usePageTitle';
 
 function CertificateDetail() {
   const { encodedSubjectDN } = useParams();
@@ -17,6 +18,13 @@ function CertificateDetail() {
   });
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [deleting, setDeleting] = useState(false);
+
+  usePageTitle(
+    formatPageTitle(
+      certificate?.subject_dn ? truncateTitle(certificate.subject_dn) : null,
+      'Certificate'
+    )
+  );
 
   useEffect(() => {
     const fetchCertificate = async () => {

--- a/src/frontend/src/pages/assets/Certificates.js
+++ b/src/frontend/src/pages/assets/Certificates.js
@@ -4,8 +4,10 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { certificateAPI, programAPI } from '../../services/api';
 import { useProgramFilter } from '../../contexts/ProgramFilterContext';
 import { formatDate } from '../../utils/dateUtils';
+import { usePageTitle, formatPageTitle } from '../../hooks/usePageTitle';
 
 function Certificates() {
+  usePageTitle(formatPageTitle('Certificates'));
   const navigate = useNavigate();
   const location = useLocation();
   const { selectedProgram, setSelectedProgram } = useProgramFilter();

--- a/src/frontend/src/pages/assets/IPDetail.js
+++ b/src/frontend/src/pages/assets/IPDetail.js
@@ -4,6 +4,7 @@ import { Container, Row, Col, Card, Badge, Button, Spinner, Alert, Table, Collap
 import { ipAPI, domainAPI } from '../../services/api';
 import NotesSection from '../../components/NotesSection';
 import { formatDate } from '../../utils/dateUtils';
+import { usePageTitle, formatPageTitle } from '../../hooks/usePageTitle';
 
 function IPDetail() {
   const { ipAddress } = useParams();
@@ -20,6 +21,8 @@ function IPDetail() {
   const [relatedSubdomains, setRelatedSubdomains] = useState([]);
   const [subdomainsLoading, setSubdomainsLoading] = useState(false);
   const [subdomainsError, setSubdomainsError] = useState(null);
+
+  usePageTitle(formatPageTitle(ip?.ip, 'IP'));
 
   useEffect(() => {
     const fetchIp = async () => {

--- a/src/frontend/src/pages/assets/IPs.js
+++ b/src/frontend/src/pages/assets/IPs.js
@@ -4,8 +4,10 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { ipAPI, programAPI } from '../../services/api';
 import { useProgramFilter } from '../../contexts/ProgramFilterContext';
 import { formatDate } from '../../utils/dateUtils';
+import { usePageTitle, formatPageTitle } from '../../hooks/usePageTitle';
 
 function IPs() {
+  usePageTitle(formatPageTitle('IPs'));
   const navigate = useNavigate();
   const location = useLocation();
   const { selectedProgram, setSelectedProgram } = useProgramFilter();

--- a/src/frontend/src/pages/assets/Screenshots.js
+++ b/src/frontend/src/pages/assets/Screenshots.js
@@ -4,6 +4,7 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { useProgramFilter } from '../../contexts/ProgramFilterContext';
 import { screenshotAPI, API_BASE_URL } from '../../services/api';
 import { formatDate } from '../../utils/dateUtils';
+import { usePageTitle, formatPageTitle } from '../../hooks/usePageTitle';
 
 // Add Font Awesome CSS if not already loaded
 const loadFontAwesome = () => {
@@ -114,6 +115,7 @@ const LazyImage = ({ src, alt, style, onClick, onError, placeholder }) => {
 };
 
 function Screenshots() {
+  usePageTitle(formatPageTitle('Screenshots'));
   const navigate = useNavigate();
   const location = useLocation();
   const { selectedProgram, setSelectedProgram } = useProgramFilter();

--- a/src/frontend/src/pages/assets/ServiceDetail.js
+++ b/src/frontend/src/pages/assets/ServiceDetail.js
@@ -4,6 +4,7 @@ import { Container, Row, Col, Card, Badge, Button, Spinner, Alert, Table, Collap
 import { serviceAPI } from '../../services/api';
 import NotesSection from '../../components/NotesSection';
 import { formatDate } from '../../utils/dateUtils';
+import { usePageTitle, formatPageTitle } from '../../hooks/usePageTitle';
 
 function ServiceDetail() {
   const { ip, port } = useParams();
@@ -17,6 +18,13 @@ function ServiceDetail() {
   });
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [deleting, setDeleting] = useState(false);
+
+  usePageTitle(
+    formatPageTitle(
+      service?.ip != null && service?.port != null ? `${service.ip}:${service.port}` : null,
+      'Service'
+    )
+  );
 
   useEffect(() => {
     const fetchService = async () => {

--- a/src/frontend/src/pages/assets/Services.js
+++ b/src/frontend/src/pages/assets/Services.js
@@ -4,8 +4,10 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { serviceAPI, programAPI } from '../../services/api';
 import { useProgramFilter } from '../../contexts/ProgramFilterContext';
 import { formatDate } from '../../utils/dateUtils';
+import { usePageTitle, formatPageTitle } from '../../hooks/usePageTitle';
 
 function Services() {
+  usePageTitle(formatPageTitle('Services'));
   const navigate = useNavigate();
   const location = useLocation();
   const { selectedProgram, setSelectedProgram } = useProgramFilter();

--- a/src/frontend/src/pages/assets/SubdomainDetail.js
+++ b/src/frontend/src/pages/assets/SubdomainDetail.js
@@ -4,6 +4,7 @@ import { Container, Row, Col, Card, Badge, Button, Spinner, Alert, Table, Collap
 import { domainAPI } from '../../services/api';
 import NotesSection from '../../components/NotesSection';
 import { formatDate } from '../../utils/dateUtils';
+import { usePageTitle, formatPageTitle } from '../../hooks/usePageTitle';
 
 function SubdomainDetail() {
   const { domainName } = useParams();
@@ -17,6 +18,8 @@ function SubdomainDetail() {
   });
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [deleting, setDeleting] = useState(false);
+
+  usePageTitle(formatPageTitle(domain?.name, 'Subdomain'));
 
   useEffect(() => {
     const fetchDomain = async () => {

--- a/src/frontend/src/pages/assets/Subdomains.js
+++ b/src/frontend/src/pages/assets/Subdomains.js
@@ -4,8 +4,10 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { domainAPI, programAPI } from '../../services/api';
 import { useProgramFilter } from '../../contexts/ProgramFilterContext';
 import { formatDate } from '../../utils/dateUtils';
+import { usePageTitle, formatPageTitle } from '../../hooks/usePageTitle';
 
 function Subdomains() {
+  usePageTitle(formatPageTitle('Subdomains'));
   const navigate = useNavigate();
   const location = useLocation();
   const { selectedProgram, setSelectedProgram } = useProgramFilter();

--- a/src/frontend/src/pages/assets/Technologies.js
+++ b/src/frontend/src/pages/assets/Technologies.js
@@ -3,8 +3,10 @@ import { Container, Row, Col, Card, Badge, Pagination, Form, Button, Spinner, Al
 import { useNavigate } from 'react-router-dom';
 import { urlAPI } from '../../services/api';
 import { useProgramFilter } from '../../contexts/ProgramFilterContext';
+import { usePageTitle, formatPageTitle } from '../../hooks/usePageTitle';
 
 function Technologies() {
+  usePageTitle(formatPageTitle('Technologies'));
   const navigate = useNavigate();
   const { selectedProgram } = useProgramFilter();
   const [technologies, setTechnologies] = useState({});

--- a/src/frontend/src/pages/assets/URLDetail.js
+++ b/src/frontend/src/pages/assets/URLDetail.js
@@ -5,6 +5,7 @@ import { urlAPI, screenshotAPI, serviceAPI, certificateAPI, domainAPI, API_BASE_
 import NotesSection from '../../components/NotesSection';
 import SitemapTree from '../../components/SitemapTree';
 import { formatDate } from '../../utils/dateUtils';
+import { usePageTitle, formatPageTitle, truncateTitle } from '../../hooks/usePageTitle';
 
 function URLDetail() {
   const { encodedUrl } = useParams();
@@ -28,6 +29,8 @@ function URLDetail() {
   const [relatedServices, setRelatedServices] = useState([]);
   const [relatedSubdomain, setRelatedSubdomain] = useState(null);
   const [relatedAssetsLoading, setRelatedAssetsLoading] = useState(false);
+
+  usePageTitle(formatPageTitle(url?.url ? truncateTitle(url.url) : null, 'URL'));
 
   // Function to fetch related assets (certificate, services, subdomain)
   const fetchRelatedAssets = async (urlData) => {

--- a/src/frontend/src/pages/assets/URLs.js
+++ b/src/frontend/src/pages/assets/URLs.js
@@ -4,6 +4,7 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { urlAPI, programAPI } from '../../services/api';
 import { useProgramFilter } from '../../contexts/ProgramFilterContext';
 import { formatDate } from '../../utils/dateUtils';
+import { usePageTitle, formatPageTitle } from '../../hooks/usePageTitle';
 
 // Add Font Awesome CSS if not already loaded
 const loadFontAwesome = () => {
@@ -16,6 +17,7 @@ const loadFontAwesome = () => {
 };
 
 function URLs() {
+  usePageTitle(formatPageTitle('URLs'));
   const navigate = useNavigate();
   const location = useLocation();
   const { selectedProgram, setSelectedProgram } = useProgramFilter();

--- a/src/frontend/src/pages/dashboards/TyposquatActionLogs.js
+++ b/src/frontend/src/pages/dashboards/TyposquatActionLogs.js
@@ -14,6 +14,7 @@ import {
 import { useProgramFilter } from '../../contexts/ProgramFilterContext';
 import api from '../../services/api';
 import { formatDate } from '../../utils/dateUtils';
+import { usePageTitle, formatPageTitle } from '../../hooks/usePageTitle';
 
 const LogLevelBadge = ({ level }) => {
   const variants = {
@@ -257,6 +258,7 @@ const ConsoleControls = ({
 };
 
 function TyposquatActionLogs() {
+  usePageTitle(formatPageTitle('Typosquat Action Logs'));
   const { selectedProgram } = useProgramFilter();
 
   // State

--- a/src/frontend/src/pages/dashboards/TyposquatDashboard.js
+++ b/src/frontend/src/pages/dashboards/TyposquatDashboard.js
@@ -12,6 +12,7 @@ import {
 } from 'react-bootstrap';
 import { useProgramFilter } from '../../contexts/ProgramFilterContext';
 import api from '../../services/api';
+import { usePageTitle, formatPageTitle } from '../../hooks/usePageTitle';
 
 // Simple chart components (you can replace these with a charting library like Chart.js or Recharts)
 const SimpleBarChart = ({ data, title }) => {
@@ -469,6 +470,7 @@ function getDefaultCustomRange() {
 }
 
 function TyposquatDashboard() {
+  usePageTitle(formatPageTitle('Typosquat Dashboard'));
   const { selectedProgram, programs } = useProgramFilter();
 
   const initialCustom = getDefaultCustomRange();

--- a/src/frontend/src/pages/findings/BrokenLinkDetail.js
+++ b/src/frontend/src/pages/findings/BrokenLinkDetail.js
@@ -4,6 +4,7 @@ import { Container, Card, Badge, Row, Col, Button, Alert, Spinner, Table, Modal 
 import { brokenLinksAPI } from '../../services/api';
 import NotesSection from '../../components/NotesSection';
 import { formatDate } from '../../utils/dateUtils';
+import { usePageTitle, formatPageTitle, truncateTitle } from '../../hooks/usePageTitle';
 
 function BrokenLinkDetail() {
   const [searchParams] = useSearchParams();
@@ -17,6 +18,12 @@ function BrokenLinkDetail() {
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [updateSuccess, setUpdateSuccess] = useState(false);
+
+  const brokenLinkLabel =
+    finding?.url || finding?.domain
+      ? truncateTitle(finding.url || finding.domain)
+      : null;
+  usePageTitle(formatPageTitle(brokenLinkLabel, 'Broken Link'));
 
   const fetchFinding = useCallback(async () => {
     setLoading(true);

--- a/src/frontend/src/pages/findings/BrokenLinks.js
+++ b/src/frontend/src/pages/findings/BrokenLinks.js
@@ -4,8 +4,10 @@ import { Container, Card, Table, Badge, Form, Row, Col, Button, Pagination, Aler
 import { brokenLinksAPI } from '../../services/api';
 import { useProgramFilter } from '../../contexts/ProgramFilterContext';
 import { formatDate } from '../../utils/dateUtils';
+import { usePageTitle, formatPageTitle } from '../../hooks/usePageTitle';
 
 function BrokenLinks() {
+  usePageTitle(formatPageTitle('Broken Links'));
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const { selectedProgram } = useProgramFilter();

--- a/src/frontend/src/pages/findings/ExternalLinks.js
+++ b/src/frontend/src/pages/findings/ExternalLinks.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useContext, useCallback } from 'react';
 import { Container, Card, Form, Col, Button, Table, Collapse, Row, Modal, Spinner, Pagination, OverlayTrigger, Popover } from 'react-bootstrap';
 import { ProgramFilterContext } from '../../contexts/ProgramFilterContext';
 import api from '../../services/api';
+import { usePageTitle, formatPageTitle } from '../../hooks/usePageTitle';
 
 // Add Font Awesome CSS if not already loaded
 const loadFontAwesome = () => {
@@ -14,6 +15,7 @@ const loadFontAwesome = () => {
 };
 
 function ExternalLinks() {
+  usePageTitle(formatPageTitle('External Links'));
   const [externalLinksData, setExternalLinksData] = useState({});
   const [rootSitesList, setRootSitesList] = useState([]);
   const [loading, setLoading] = useState(true);

--- a/src/frontend/src/pages/findings/NucleiFindingDetail.js
+++ b/src/frontend/src/pages/findings/NucleiFindingDetail.js
@@ -5,6 +5,7 @@ import AceEditor from 'react-ace';
 import api from '../../services/api';
 import NotesSection from '../../components/NotesSection';
 import { formatDate } from '../../utils/dateUtils';
+import { usePageTitle, formatPageTitle } from '../../hooks/usePageTitle';
 
 // Import Ace editor modes and themes
 import 'ace-builds/src-noconflict/mode-yaml';
@@ -136,6 +137,8 @@ const NucleiFindingDetail = () => {
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [templateContentExpanded, setTemplateContentExpanded] = useState(false);
+
+  usePageTitle(formatPageTitle(finding?.name || finding?.template_id, 'Nuclei'));
 
   const severityColors = {
     critical: 'danger',

--- a/src/frontend/src/pages/findings/NucleiFindings.js
+++ b/src/frontend/src/pages/findings/NucleiFindings.js
@@ -4,8 +4,10 @@ import { Row, Col, Form, Button, Modal, Spinner, Pagination, Badge, OverlayTrigg
 import api from '../../services/api';
 import { useProgramFilter } from '../../contexts/ProgramFilterContext';
 import { formatDate } from '../../utils/dateUtils';
+import { usePageTitle, formatPageTitle } from '../../hooks/usePageTitle';
 
 const NucleiFindings = () => {
+  usePageTitle(formatPageTitle('Nuclei Findings'));
   const location = useLocation();
   const navigate = useNavigate();
   const [findings, setFindings] = useState([]);

--- a/src/frontend/src/pages/findings/SSLCertificateDashboard.js
+++ b/src/frontend/src/pages/findings/SSLCertificateDashboard.js
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import api from '../../services/api';
 import { useProgramFilter } from '../../contexts/ProgramFilterContext';
 import { formatDate } from '../../utils/dateUtils';
+import { usePageTitle, formatPageTitle } from '../../hooks/usePageTitle';
 
 // Enhanced parsing functions for SSL/TLS extracted results (outside component to prevent re-creation)
 const parseExtractedResults = (extracted) => {
@@ -157,6 +158,7 @@ const parseCertificateIssuer = (extractedResults) => {
 };
 
 const SSLCertificateDashboard = () => {
+  usePageTitle(formatPageTitle('SSL Certificate Dashboard'));
   const { selectedProgram } = useProgramFilter();
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);

--- a/src/frontend/src/pages/findings/TyposquatFindingDetail.js
+++ b/src/frontend/src/pages/findings/TyposquatFindingDetail.js
@@ -20,6 +20,7 @@ import RelatedScreenshotsViewer from '../../components/RelatedScreenshotsViewer'
 import { formatDate, formatLocalDate } from '../../utils/dateUtils';
 import { useAuth } from '../../contexts/AuthContext';
 import { formatAssignedTo, initializeUserCache, preloadUsers } from '../../utils/userUtils';
+import { usePageTitle, formatPageTitle } from '../../hooks/usePageTitle';
 
 const WHOIS_FLAT_KEYS = [
   'whois_registrar',
@@ -154,6 +155,8 @@ function TyposquatFindingDetail() {
   // Action logs state
   const [actionLogs, setActionLogs] = useState([]);
   const [actionLogsLoading, setActionLogsLoading] = useState(false);
+
+  usePageTitle(formatPageTitle(finding?.typo_domain, 'Typosquat'));
 
   // Fetch finding details
   useEffect(() => {

--- a/src/frontend/src/pages/findings/TyposquatFindings.js
+++ b/src/frontend/src/pages/findings/TyposquatFindings.js
@@ -22,11 +22,13 @@ import { useAuth } from '../../contexts/AuthContext';
 import api, { jobAPI, userManagementAPI } from '../../services/api';
 import { formatDate } from '../../utils/dateUtils';
 import { initializeUserCache } from '../../utils/userUtils';
+import { usePageTitle, formatPageTitle } from '../../hooks/usePageTitle';
 
 /** Keep in sync with API `AI_ANALYSIS_BATCH_MAX_FINDINGS` in typosquat_findings.py (temporary cap). */
 const AI_ANALYSIS_BATCH_MAX_FINDINGS = 10;
 
 function TyposquatFindings() {
+  usePageTitle(formatPageTitle('Typosquat Findings'));
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const location = useLocation();

--- a/src/frontend/src/pages/findings/TyposquatScreenshots.js
+++ b/src/frontend/src/pages/findings/TyposquatScreenshots.js
@@ -4,6 +4,7 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { useProgramFilter } from '../../contexts/ProgramFilterContext';
 import { typosquatScreenshotAPI, API_BASE_URL } from '../../services/api';
 import { formatDate } from '../../utils/dateUtils';
+import { usePageTitle, formatPageTitle } from '../../hooks/usePageTitle';
 
 // Add Font Awesome CSS if not already loaded
 const loadFontAwesome = () => {
@@ -114,6 +115,7 @@ const LazyImage = ({ src, alt, style, onClick, onError, placeholder }) => {
 };
 
 function TyposquatScreenshots() {
+  usePageTitle(formatPageTitle('Typosquat Screenshots'));
   const navigate = useNavigate();
   const location = useLocation();
   const { selectedProgram, setSelectedProgram } = useProgramFilter();

--- a/src/frontend/src/pages/findings/TyposquatUrlDetails.js
+++ b/src/frontend/src/pages/findings/TyposquatUrlDetails.js
@@ -5,6 +5,7 @@ import { typosquatAPI } from '../../services/api';
 import NotesSection from '../../components/NotesSection';
 import { formatDate } from '../../utils/dateUtils';
 import ScreenshotsViewer from '../../components/ScreenshotsViewer';
+import { usePageTitle, formatPageTitle, truncateTitle } from '../../hooks/usePageTitle';
 
 function TyposquatUrlDetails() {
   const { id } = useParams();
@@ -24,6 +25,13 @@ function TyposquatUrlDetails() {
   // Certificate state
   const [certificate, setCertificate] = useState(null);
   const [certificateLoading, setCertificateLoading] = useState(false);
+
+  const domainParam = new URLSearchParams(location.search).get('domain');
+  usePageTitle(
+    viewMode === 'list' && domainParam
+      ? formatPageTitle(`URLs · ${domainParam}`, 'Typosquat')
+      : formatPageTitle(url?.url ? truncateTitle(url.url) : null, 'Typosquat URL')
+  );
 
   useEffect(() => {
     const fetchData = async () => {

--- a/src/frontend/src/pages/findings/TyposquatUrls.js
+++ b/src/frontend/src/pages/findings/TyposquatUrls.js
@@ -4,6 +4,7 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { typosquatAPI } from '../../services/api';
 import { useProgramFilter } from '../../contexts/ProgramFilterContext';
 import { formatDate } from '../../utils/dateUtils';
+import { usePageTitle, formatPageTitle } from '../../hooks/usePageTitle';
 
 // Add Font Awesome CSS if not already loaded
 const loadFontAwesome = () => {
@@ -16,6 +17,7 @@ const loadFontAwesome = () => {
 };
 
 function TyposquatUrls() {
+  usePageTitle(formatPageTitle('Typosquat URLs'));
   const navigate = useNavigate();
   const location = useLocation();
   const { selectedProgram, setSelectedProgram } = useProgramFilter();

--- a/src/frontend/src/pages/findings/WPScanFindingDetail.js
+++ b/src/frontend/src/pages/findings/WPScanFindingDetail.js
@@ -4,6 +4,7 @@ import { Button, Badge } from 'react-bootstrap';
 import api from '../../services/api';
 import NotesSection from '../../components/NotesSection';
 import { formatDate } from '../../utils/dateUtils';
+import { usePageTitle, formatPageTitle } from '../../hooks/usePageTitle';
 
 const WPScanFindingDetail = () => {
   const navigate = useNavigate();
@@ -13,6 +14,8 @@ const WPScanFindingDetail = () => {
   const [error, setError] = useState(null);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [deleting, setDeleting] = useState(false);
+
+  usePageTitle(formatPageTitle(finding?.title || finding?.item_name, 'WPScan'));
 
   const severityColors = {
     critical: 'danger',

--- a/src/frontend/src/pages/findings/WPScanFindings.js
+++ b/src/frontend/src/pages/findings/WPScanFindings.js
@@ -4,8 +4,10 @@ import { Row, Col, Form, Button, Modal, Spinner, Pagination, Badge, OverlayTrigg
 import api from '../../services/api';
 import { useProgramFilter } from '../../contexts/ProgramFilterContext';
 import { formatDate } from '../../utils/dateUtils';
+import { usePageTitle, formatPageTitle } from '../../hooks/usePageTitle';
 
 const WPScanFindings = () => {
+  usePageTitle(formatPageTitle('WPScan Findings'));
   const location = useLocation();
   const navigate = useNavigate();
   const [findings, setFindings] = useState([]);

--- a/src/frontend/src/pages/programs/ProgramDetail.js
+++ b/src/frontend/src/pages/programs/ProgramDetail.js
@@ -20,6 +20,7 @@ import { programAPI, aiAPI } from '../../services/api';
 import EventHandlerForm from '../../components/EventHandlerForm';
 import { useAuth } from '../../contexts/AuthContext';
 import { formatDate } from '../../utils/dateUtils';
+import { usePageTitle, formatPageTitle } from '../../hooks/usePageTitle';
 
 const DEFAULT_NOTIFICATION_SETTINGS = {
   enabled: false,
@@ -181,6 +182,8 @@ function ProgramDetail() {
   const [eventHandlerEditingHandler, setEventHandlerEditingHandler] = useState(null);
 
   const [notificationSettings, setNotificationSettings] = useState(DEFAULT_NOTIFICATION_SETTINGS);
+
+  usePageTitle(formatPageTitle(program?.name || programName, 'Program'));
 
   const loadProgram = useCallback(async () => {
     try {

--- a/src/frontend/src/pages/programs/Programs.js
+++ b/src/frontend/src/pages/programs/Programs.js
@@ -18,8 +18,10 @@ import {
 import { programAPI } from '../../services/api';
 import { useAuth } from '../../contexts/AuthContext';
 import { formatDate } from '../../utils/dateUtils';
+import { usePageTitle, formatPageTitle } from '../../hooks/usePageTitle';
 
 function Programs() {
+  usePageTitle(formatPageTitle('Programs'));
   const navigate = useNavigate();
   const location = useLocation();
   const { hasProgramPermission, isSuperuser } = useAuth();

--- a/src/frontend/src/pages/scheduled-jobs/ScheduledJobCreate.js
+++ b/src/frontend/src/pages/scheduled-jobs/ScheduledJobCreate.js
@@ -5,6 +5,7 @@ import { scheduledJobsAPI, workflowAPI, programAPI } from '../../services/api';
 import { useAuth } from '../../contexts/AuthContext';
 import { formatLocalDateTime } from '../../utils/dateUtils';
 import VariableInput from '../../components/VariableInput';
+import { usePageTitle, formatPageTitle } from '../../hooks/usePageTitle';
 
 // Helper function to get user-friendly timezone name
 const getUserFriendlyTimezone = () => {
@@ -30,6 +31,7 @@ const getUserFriendlyTimezone = () => {
 };
 
 const ScheduledJobCreate = () => {
+  usePageTitle(formatPageTitle('Create Scheduled Job'));
   // Debug timezone detection
   const initialTimezone = getUserFriendlyTimezone();
 

--- a/src/frontend/src/pages/scheduled-jobs/ScheduledJobDetail.js
+++ b/src/frontend/src/pages/scheduled-jobs/ScheduledJobDetail.js
@@ -4,6 +4,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { scheduledJobsAPI, workflowAPI } from '../../services/api';
 import { formatDate, formatRelativeTime } from '../../utils/dateUtils';
 import VariableInput from '../../components/VariableInput';
+import { usePageTitle, formatPageTitle } from '../../hooks/usePageTitle';
 
 const ScheduledJobDetail = () => {
   const { jobId } = useParams();
@@ -27,6 +28,8 @@ const ScheduledJobDetail = () => {
   const [workflowVariables, setWorkflowVariables] = useState({});
   const [variableValues, setVariableValues] = useState({});
   const [variableErrors, setVariableErrors] = useState({});
+
+  usePageTitle(formatPageTitle(job?.name, 'Scheduled Job'));
 
   const loadJobDetails = useCallback(async () => {
     try {

--- a/src/frontend/src/pages/scheduled-jobs/ScheduledJobs.js
+++ b/src/frontend/src/pages/scheduled-jobs/ScheduledJobs.js
@@ -4,8 +4,10 @@ import { Link, useNavigate } from 'react-router-dom';
 import { scheduledJobsAPI } from '../../services/api';
 import { formatDate, formatRelativeTime } from '../../utils/dateUtils';
 import { useAuth } from '../../contexts/AuthContext';
+import { usePageTitle, formatPageTitle } from '../../hooks/usePageTitle';
 
 const ScheduledJobs = () => {
+  usePageTitle(formatPageTitle('Scheduled Jobs'));
   const [jobs, setJobs] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);

--- a/src/frontend/src/pages/workflows/WorkflowCreate.js
+++ b/src/frontend/src/pages/workflows/WorkflowCreate.js
@@ -9,8 +9,7 @@ import { useProgramFilter } from '../../contexts/ProgramFilterContext';
 import { useAuth } from '../../contexts/AuthContext';
 import VisualWorkflowBuilder from '../../components/VisualWorkflowBuilder';
 import { useWorkflowStore } from '../../stores/workflowStore';
-
-
+import { usePageTitle, formatPageTitle } from '../../hooks/usePageTitle';
 
 function WorkflowCreate() {
   const { workflowId } = useParams();
@@ -41,6 +40,10 @@ function WorkflowCreate() {
     clearWorkflow,
     getWorkflowPayload,
   } = useWorkflowStore();
+
+  usePageTitle(
+    isEdit ? formatPageTitle(workflowName || undefined, 'Edit Workflow') : formatPageTitle('Create Workflow')
+  );
 
   useEffect(() => {
     if (isEdit) {

--- a/src/frontend/src/pages/workflows/WorkflowList.js
+++ b/src/frontend/src/pages/workflows/WorkflowList.js
@@ -3,8 +3,10 @@ import { Container, Row, Col, Card, Table, Button, Badge, Alert, Spinner, Modal,
 import { Link } from 'react-router-dom';
 import { workflowAPI } from '../../services/api';
 import { useAuth } from '../../contexts/AuthContext';
+import { usePageTitle, formatPageTitle } from '../../hooks/usePageTitle';
 
 function WorkflowList() {
+  usePageTitle(formatPageTitle('Workflow List'));
   // Use auth context to check superuser status
   const { isSuperuser } = useAuth();
   

--- a/src/frontend/src/pages/workflows/WorkflowRun.js
+++ b/src/frontend/src/pages/workflows/WorkflowRun.js
@@ -6,6 +6,7 @@ import JsonEditor from '../../components/JsonEditor';
 import VariableInput from '../../components/VariableInput';
 import VisualWorkflowBuilder from '../../components/VisualWorkflowBuilder';
 import { validateVariables, processTemplate } from '../../utils/workflowTemplates';
+import { usePageTitle, formatPageTitle } from '../../hooks/usePageTitle';
 
 function WorkflowRun() {
   const { workflowId } = useParams();
@@ -32,6 +33,8 @@ function WorkflowRun() {
   const [visualVariables, setVisualVariables] = useState({});
   const [visualInputs, setVisualInputs] = useState({});
   const [visualWorkflowJson, setVisualWorkflowJson] = useState('');
+
+  usePageTitle(formatPageTitle(workflowDetails?.name, 'Run Workflow'));
 
   // Default template for custom workflows
   const defaultWorkflowTemplate = JSON.stringify({

--- a/src/frontend/src/pages/workflows/WorkflowStatus.js
+++ b/src/frontend/src/pages/workflows/WorkflowStatus.js
@@ -3,6 +3,7 @@ import { Container, Row, Col, Card, Table, Badge, Button, Spinner, Alert, Pagina
 import { Link } from 'react-router-dom';
 import { workflowAPI } from '../../services/api';
 import { formatDate, calculateDuration } from '../../utils/dateUtils';
+import { usePageTitle, formatPageTitle } from '../../hooks/usePageTitle';
 
 // Add some custom styles for sortable headers
 const sortableHeaderStyle = {
@@ -11,6 +12,7 @@ const sortableHeaderStyle = {
 };
 
 function WorkflowStatus() {
+  usePageTitle(formatPageTitle('Workflow Status'));
   const [executions, setExecutions] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);

--- a/src/frontend/src/pages/workflows/WorkflowStatusDetail.js
+++ b/src/frontend/src/pages/workflows/WorkflowStatusDetail.js
@@ -4,6 +4,7 @@ import { Container, Row, Col, Card, Badge, Button, Spinner, Alert, Modal, Button
 import { workflowAPI } from '../../services/api';
 import { formatDate, calculateDuration } from '../../utils/dateUtils';
 import './WorkflowStatusDetail.css';
+import { usePageTitle, formatPageTitle } from '../../hooks/usePageTitle';
 
 function WorkflowStatusDetail() {
   const { workflowId } = useParams();
@@ -21,6 +22,8 @@ function WorkflowStatusDetail() {
   const [podOutputSearch, setPodOutputSearch] = useState('');
   const [podOutputMatchIndex, setPodOutputMatchIndex] = useState(0);
   const podOutputContainerRef = useRef(null);
+
+  usePageTitle(formatPageTitle(logs?.workflow_name || workflowId, 'Workflow Run'));
 
   const loadWorkflowDetails = useCallback(async () => {
     try {

--- a/src/frontend/src/pages/workflows/Workflows.js
+++ b/src/frontend/src/pages/workflows/Workflows.js
@@ -3,8 +3,10 @@ import { Container, Row, Col, Card, Button, Badge, Alert, Spinner } from 'react-
 import { Link, useSearchParams } from 'react-router-dom';
 import { workflowAPI } from '../../services/api';
 import SingleTaskModal from '../../components/workflow/SingleTaskModal';
+import { usePageTitle, formatPageTitle } from '../../hooks/usePageTitle';
 
 function Workflows() {
+  usePageTitle(formatPageTitle('Workflows'));
   const [searchParams, setSearchParams] = useSearchParams();
   const [recentExecutions, setRecentExecutions] = useState([]);
   const [savedWorkflows, setSavedWorkflows] = useState([]);


### PR DESCRIPTION
Add formatPageTitle, usePageTitle, and truncateTitle so each route updates document.title after mount. List and admin pages use fixed labels; detail pages include the primary entity field where available. Long URLs and certificate subject DNs are shortened for readable tabs. Multi-word labels use Title Case for consistency with the UI.

Made-with: Cursor