### PR TITLE
chore(k8s): add health probes and structured /status across services

### DIFF
--- a/.cursor/rules/event-handler-architecture.mdc
+++ b/.cursor/rules/event-handler-architecture.mdc
@@ -1,5 +1,5 @@
 ---
-globs: ["src/event-handler/app/main.py", "src/event-handler/app/config.py", "src/event-handler/app/nats_client.py"]
+globs: ["src/event-handler/app/main.py", "src/event-handler/app/config.py", "src/event-handler/app/nats_client.py", "src/event-handler/app/http_api.py"]
 ---
 
 # Event-Handler Architecture Overview
@@ -12,6 +12,7 @@ The event-handler (notifier) service processes events from NATS JetStream and ex
 
 ```
 Event-Handler Service (SimpleNotifierApp)
+├── HTTP API (http_api.py) — uvicorn on EVENTHANDLER_HTTP_HOST:PORT (default :8080); GET /status; room for pause/start later
 ├── EventsSubscriber (nats_client.py)
 │   ├── NATS JetStream connection
 │   ├── Durable consumer management
@@ -70,7 +71,7 @@ sequenceDiagram
   - Handle batch vs single events from API
   - Run batch recovery background loop
 - **Key Methods**:
-  - `start()` - Initialize and start event loop
+  - `start()` - Connect NATS, start uvicorn HTTP server (concurrent with subscriber loop), run event loop
   - `handle_event()` - Main event routing
   - `_handle_batch_event()` - Process API batch events
   - `_handle_single_event()` - Process individual events

--- a/kubernetes/base/api/api-deployment.yaml
+++ b/kubernetes/base/api/api-deployment.yaml
@@ -239,13 +239,24 @@ spec:
         - name: LOG_LEVEL
           value: "INFO"
 
+        # Liveness: process up; no DB/NATS (avoids restart loops on dependency blips)
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 8000
+          initialDelaySeconds: 15
+          periodSeconds: 20
+          timeoutSeconds: 3
+          failureThreshold: 3
+
+        # Readiness: dependency-aware /status (503 when DB down by default)
         readinessProbe:
           httpGet:
             path: /status
             port: 8000
           initialDelaySeconds: 5
           periodSeconds: 5
-          timeoutSeconds: 3
+          timeoutSeconds: 5
           failureThreshold: 6
 
         resources:

--- a/kubernetes/base/ct-monitor/deployment.yaml
+++ b/kubernetes/base/ct-monitor/deployment.yaml
@@ -67,26 +67,24 @@ spec:
           containerPort: 8002
           protocol: TCP
         
+        # Liveness: cheap HTTP ping (no heavy status payload)
         livenessProbe:
-          exec:
-            command:
-            - python
-            - -c
-            - "from main import CTMonitorService; print('OK')"
+          httpGet:
+            path: /health
+            port: http
           initialDelaySeconds: 30
           periodSeconds: 60
-          timeoutSeconds: 10
+          timeoutSeconds: 5
           failureThreshold: 3
         
         readinessProbe:
-          exec:
-            command:
-            - python
-            - -c
-            - "import aiohttp; import nats; import cryptography; print('OK')"
+          httpGet:
+            path: /status
+            port: http
           initialDelaySeconds: 10
           periodSeconds: 30
           timeoutSeconds: 5
+          failureThreshold: 3
       restartPolicy: Always
       terminationGracePeriodSeconds: 30
 

--- a/kubernetes/base/event-handler/event-handler-deployment.yaml
+++ b/kubernetes/base/event-handler/event-handler-deployment.yaml
@@ -51,9 +51,35 @@ spec:
         
         - name: EVENTHANDLER_ENABLE_EVENT_HANDLERS
           value: "true"
+
+        - name: EVENTHANDLER_HTTP_PORT
+          value: "8000"
         
         - name: LOG_LEVEL
           value: "DEBUG"
+
+        ports:
+        - name: http
+          containerPort: 8000
+          protocol: TCP
+
+        # Liveness: HTTP server listening; avoid NATS/Redis flapping (those are readiness)
+        livenessProbe:
+          tcpSocket:
+            port: http
+          initialDelaySeconds: 30
+          periodSeconds: 20
+          timeoutSeconds: 3
+          failureThreshold: 3
+
+        readinessProbe:
+          httpGet:
+            path: /status
+            port: http
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 3
+          failureThreshold: 3
         
         resources:
           requests:

--- a/kubernetes/base/frontend/frontend-deployment.yaml
+++ b/kubernetes/base/frontend/frontend-deployment.yaml
@@ -57,18 +57,24 @@ spec:
           limits:
             memory: "256Mi"
             cpu: "200m"
+        # Liveness: accept connections only (nginx process alive)
         livenessProbe:
-          httpGet:
-            path: /
+          tcpSocket:
             port: 80
           initialDelaySeconds: 30
           periodSeconds: 10
+          timeoutSeconds: 3
+          failureThreshold: 3
+
+        # Readiness: JSON health file + config path (see nginx-config /status)
         readinessProbe:
           httpGet:
-            path: /
+            path: /status
             port: 80
           initialDelaySeconds: 5
           periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 3
       volumes:
       - name: nginx-config
         configMap:

--- a/kubernetes/base/frontend/nginx-config.yaml
+++ b/kubernetes/base/frontend/nginx-config.yaml
@@ -19,6 +19,13 @@ data:
         root /usr/share/nginx/html;
         index index.html index.htm;
 
+        # Health / readiness (JSON; status.json from build, version set in image Dockerfile)
+        location = /status {
+            rewrite ^ /status.json break;
+            default_type application/json;
+            add_header Cache-Control "no-store";
+        }
+
         # Handle client-side routing
         location / {
             try_files $uri $uri/ /index.html;

--- a/kubernetes/base/nats/nats-deployment.yaml
+++ b/kubernetes/base/nats/nats-deployment.yaml
@@ -41,6 +41,26 @@ spec:
         - name: nats-scripts
           mountPath: /init.sh
           subPath: init.sh
+
+        # Liveness: client port accepting (server process bound)
+        livenessProbe:
+          tcpSocket:
+            port: client
+          initialDelaySeconds: 20
+          periodSeconds: 20
+          timeoutSeconds: 3
+          failureThreshold: 3
+
+        # Readiness: HTTP monitoring /varz (JetStream + server actually responding)
+        readinessProbe:
+          httpGet:
+            path: /varz
+            port: monitoring
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          timeoutSeconds: 3
+          failureThreshold: 6
+
       volumes:
       - name: nats-data
         emptyDir: {}

--- a/kubernetes/base/postgresql/postgresql-deployment.yaml
+++ b/kubernetes/base/postgresql/postgresql-deployment.yaml
@@ -21,6 +21,7 @@ spec:
         image: postgres:15
         ports:
         - containerPort: 5432
+          name: postgres
         env:
         - name: POSTGRES_USER
           valueFrom:
@@ -44,6 +45,39 @@ spec:
           limits:
             memory: "512Mi"
             cpu: "500m"
+
+        # Startup: give slow PVC / crash recovery time before liveness can restart the pod
+        startupProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - exec pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 36
+        # Liveness: exec via local socket (trust); -h 127.0.0.1 can fail auth depending on pg_hba.conf
+        livenessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - exec pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+          periodSeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 3
+
+        # Readiness: gates Service endpoints after startupProbe has succeeded
+        readinessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - exec pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 3
+
         volumeMounts:
         - name: postgresql-data
           mountPath: /var/lib/postgresql/data

--- a/kubernetes/base/redis/redis-deployment.yaml
+++ b/kubernetes/base/redis/redis-deployment.yaml
@@ -39,6 +39,27 @@ spec:
         - name: redis-config
           mountPath: /usr/local/etc/redis/redis.conf
           subPath: redis.conf
+
+        # Liveness: accept TCP on Redis port (process listening)
+        livenessProbe:
+          tcpSocket:
+            port: redis
+          initialDelaySeconds: 20
+          periodSeconds: 15
+          timeoutSeconds: 3
+          failureThreshold: 3
+
+        # Readiness: RESP-level check (PONG)
+        readinessProbe:
+          exec:
+            command:
+            - redis-cli
+            - ping
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 3
+
       volumes:
       - name: redis-data
         emptyDir: {}

--- a/src/api/app/main.py
+++ b/src/api/app/main.py
@@ -6,6 +6,7 @@ from routes import assets, programs, findings, workflows, auth, nuclei_templates
 from middleware.auth import AuthMiddleware
 from middleware.maintenance import MaintenanceMiddleware
 from config.settings import settings
+from db import init_database, test_connection
 import asyncio
 import logging
 import os
@@ -18,8 +19,8 @@ else:
 logger = logging.getLogger(__name__)
 
 app = FastAPI(
-    title="Recon API",
-    description="API for Recon",
+    title="ReconHawx API",
+    description="API for ReconHawx",
     version=os.getenv("APP_VERSION", "dev"),
     openapi_url=f"{settings.API_V1_STR}/openapi.json",
     docs_url=f"{settings.API_V1_STR}/docs",
@@ -170,7 +171,6 @@ async def startup_event():
 def initialize_database():
     """Initialize database tables and default parameters"""
     try:
-        from db import init_database, test_connection
         logger.debug("Testing database connection...")
         
         # Test connection first
@@ -306,14 +306,18 @@ async def shutdown_event():
 @app.get("/")
 async def root():
     """Health check endpoint"""
-    return {"status": "healthy", "service": "unified-api"}
+    return {"status": "healthy", "service": "api"}
 
 @app.get("/status")
 async def status():
-    """Service status endpoint"""
-    return {
-        "status": "operational",
-        "service": "unified-api",
-        "version": os.getenv("APP_VERSION", "dev"),
-        "features": ["data-management", "workflow-execution"]
-    } 
+    """
+    Service health for operators and Kubernetes readiness (path: /status).
+
+    Returns 503 when PostgreSQL is unavailable (default), or when any check
+    fails if ``API_READINESS_STRICT=true``. Redis, NATS/JetStream, and internal
+    service token are always reported under ``checks``.
+    """
+    from services.health import get_health_payload
+
+    payload, status_code = await get_health_payload()
+    return JSONResponse(content=payload, status_code=status_code)

--- a/src/api/app/services/health.py
+++ b/src/api/app/services/health.py
@@ -1,0 +1,188 @@
+"""
+Aggregated health checks for the API (database, Redis, NATS, internal auth).
+
+Default readiness: HTTP 503 only when PostgreSQL is unavailable. Redis, NATS,
+or internal-auth failures set overall ``degraded`` with HTTP 200.
+
+Set ``API_READINESS_STRICT=true`` to return 503 if any check fails (strict
+cluster readiness).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Any, Dict, List, Literal, Tuple, TypedDict
+
+import redis
+from nats.aio.client import Client as NATS
+
+from config.settings import settings
+from db import test_connection
+
+logger = logging.getLogger(__name__)
+
+CheckStatus = Literal["ok", "error", "skipped"]
+
+
+class CheckResult(TypedDict, total=False):
+    status: CheckStatus
+    detail: str
+    stream: str
+
+
+async def _check_database() -> CheckResult:
+    try:
+        ok = await asyncio.to_thread(test_connection)
+        if ok:
+            return {"status": "ok"}
+        return {"status": "error", "detail": "connection or query failed"}
+    except Exception as e:
+        logger.warning("Database health check failed: %s", e)
+        return {"status": "error", "detail": str(e)}
+
+
+async def _check_redis() -> CheckResult:
+    redis_url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+
+    def _ping() -> None:
+        r = redis.from_url(
+            redis_url,
+            decode_responses=True,
+            socket_connect_timeout=2,
+            socket_timeout=2,
+        )
+        try:
+            r.ping()
+        finally:
+            r.close()
+
+    try:
+        await asyncio.to_thread(_ping)
+        return {"status": "ok"}
+    except Exception as e:
+        logger.warning("Redis health check failed: %s", e)
+        return {"status": "error", "detail": str(e)}
+
+
+async def _check_nats() -> CheckResult:
+    url = settings.NATS_URL
+    stream = settings.EVENTS_STREAM
+
+    async def _probe() -> CheckResult:
+        nc = NATS()
+        try:
+            await nc.connect(
+                url,
+                connect_timeout=2,
+                reconnect_time_wait=0.1,
+                max_reconnect_attempts=0,
+                allow_reconnect=False,
+            )
+            js = nc.jetstream()
+            await js.stream_info(stream)
+            return {"status": "ok", "stream": stream}
+        finally:
+            try:
+                await nc.close()
+            except Exception:
+                pass
+
+    try:
+        # Bounded so readiness probes (see api-deployment readinessProbe) stay reliable.
+        return await asyncio.wait_for(_probe(), timeout=2.0)
+    except asyncio.TimeoutError:
+        logger.warning("NATS health check timed out (%s)", url)
+        return {
+            "status": "error",
+            "detail": "connection or JetStream probe timed out",
+            "stream": stream,
+        }
+    except Exception as e:
+        logger.warning("NATS health check failed: %s", e)
+        return {"status": "error", "detail": str(e), "stream": stream}
+
+
+async def _check_internal_auth() -> CheckResult:
+    key = os.getenv("INTERNAL_SERVICE_API_KEY")
+    if not key:
+        return {
+            "status": "error",
+            "detail": "INTERNAL_SERVICE_API_KEY is not set",
+        }
+    try:
+        from services.internal_token_service import InternalTokenService
+
+        token_service = InternalTokenService()
+        data = await token_service.validate_token(key)
+        if data:
+            return {"status": "ok"}
+        return {"status": "error", "detail": "token invalid or revoked"}
+    except Exception as e:
+        logger.warning("Internal auth health check failed: %s", e)
+        return {"status": "error", "detail": str(e)}
+
+
+def _rollup_status(checks: Dict[str, CheckResult]) -> Literal["healthy", "degraded", "unhealthy"]:
+    db = checks.get("database", {}).get("status")
+    if db != "ok":
+        return "unhealthy"
+
+    optional_keys: List[str] = ["redis", "nats", "internal_auth"]
+    for k in optional_keys:
+        if checks.get(k, {}).get("status") != "ok":
+            return "degraded"
+    return "healthy"
+
+
+def _strict_mode() -> bool:
+    return os.getenv("API_READINESS_STRICT", "").lower() in ("1", "true", "yes")
+
+
+async def get_health_payload() -> Tuple[Dict[str, Any], int]:
+    """
+    Run all checks and return (response_body, http_status).
+    """
+    database = await _check_database()
+    if database["status"] != "ok":
+        redis_r, nats_r = await asyncio.gather(_check_redis(), _check_nats())
+        internal_r: CheckResult = {
+            "status": "error",
+            "detail": "skipped while database is unavailable",
+        }
+    else:
+        redis_r, nats_r, internal_r = await asyncio.gather(
+            _check_redis(),
+            _check_nats(),
+            _check_internal_auth(),
+        )
+
+    checks: Dict[str, CheckResult] = {
+        "database": database,
+        "redis": redis_r,
+        "nats": nats_r,
+        "internal_auth": internal_r,
+    }
+
+    strict = _strict_mode()
+    all_ok = all(c.get("status") == "ok" for c in checks.values())
+
+    if strict:
+        overall: Literal["healthy", "degraded", "unhealthy"] = (
+            "healthy" if all_ok else "unhealthy"
+        )
+        http_status = 200 if all_ok else 503
+    else:
+        overall = _rollup_status(checks)
+        http_status = 503 if checks["database"]["status"] != "ok" else 200
+
+    body: Dict[str, Any] = {
+        "status": overall,
+        "service": "api",
+        "version": os.getenv("APP_VERSION", "undefined"),
+        "checks": checks,
+    }
+    if strict:
+        body["readiness_mode"] = "strict"
+    return body, http_status

--- a/src/event-handler/app/config.py
+++ b/src/event-handler/app/config.py
@@ -41,4 +41,8 @@ class NotifierConfig:
     # Concurrency: max messages processed concurrently per fetch batch (0 = sequential)
     max_concurrent_messages: int = int(os.getenv("EVENTHANDLER_MAX_CONCURRENT_MESSAGES", "25"))
 
+    # HTTP API (health, future pause/start)
+    http_host: str = os.getenv("EVENTHANDLER_HTTP_HOST", "0.0.0.0")
+    http_port: int = int(os.getenv("EVENTHANDLER_HTTP_PORT", "8000"))
+
 

--- a/src/event-handler/app/http_api.py
+++ b/src/event-handler/app/http_api.py
@@ -1,0 +1,98 @@
+"""
+Small HTTP control surface for the event-handler (health today; pause/start later).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import TYPE_CHECKING, Any, Dict, Literal, Tuple
+
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+
+if TYPE_CHECKING:
+    from .main import SimpleNotifierApp
+
+logger = logging.getLogger(__name__)
+
+
+def create_http_app(notifier: "SimpleNotifierApp") -> FastAPI:
+    app = FastAPI(
+        title="Event Handler",
+        description="HTTP API for health and future control operations",
+        version=os.getenv("APP_VERSION", "dev"),
+    )
+
+    @app.get("/status")
+    async def status() -> JSONResponse:
+        payload, status_code = await _status_payload(notifier)
+        return JSONResponse(content=payload, status_code=status_code)
+
+    return app
+
+
+async def _status_payload(notifier: "SimpleNotifierApp") -> Tuple[Dict[str, Any], int]:
+    nc = notifier.subscriber.nc
+    nats_connected = nc is not None and not nc.is_closed
+
+    redis_check: Dict[str, Any]
+    try:
+        await asyncio.to_thread(notifier.redis.ping)
+        redis_check = {"status": "ok"}
+    except Exception as e:
+        logger.warning("Redis health check failed: %s", e)
+        redis_check = {"status": "error", "detail": str(e)}
+
+    internal_key = notifier.cfg.internal_service_api_key
+    internal_check: Dict[str, Any]
+    if internal_key:
+        internal_check = {"status": "ok", "configured": True}
+    else:
+        internal_check = {
+            "status": "error",
+            "configured": False,
+            "detail": "INTERNAL_SERVICE_API_KEY is not set",
+        }
+
+    handlers_enabled = notifier.cfg.enable_event_handlers
+
+    checks = {
+        "nats": {
+            "status": "ok" if nats_connected else "error",
+            **(
+                {"detail": "not connected"}
+                if not nats_connected
+                else {"stream": notifier.cfg.nats_stream}
+            ),
+        },
+        "redis": redis_check,
+        "internal_auth": internal_check,
+        "event_handlers": {
+            "status": "ok" if handlers_enabled else "skipped",
+            "enabled": handlers_enabled,
+        },
+    }
+
+    overall: Literal["healthy", "degraded", "unhealthy"]
+    if not nats_connected:
+        overall = "unhealthy"
+        http_status = 503
+    elif redis_check["status"] != "ok":
+        overall = "degraded"
+        http_status = 200
+    elif internal_check["status"] != "ok":
+        overall = "degraded"
+        http_status = 200
+    else:
+        overall = "healthy"
+        http_status = 200
+
+    body: Dict[str, Any] = {
+        "status": overall,
+        "service": "event-handler",
+        "version": os.getenv("APP_VERSION", "undefined"),
+        "checks": checks,
+    }
+    return body, http_status

--- a/src/event-handler/app/main.py
+++ b/src/event-handler/app/main.py
@@ -12,8 +12,10 @@ import time
 from typing import Any, Dict
 
 import redis
+import uvicorn
 
 from .config import NotifierConfig
+from .http_api import create_http_app
 from .nats_client import EventsSubscriber
 from .program_settings import ProgramSettingsProvider
 from .event_handlers import SimpleBatchManager, close_http_client
@@ -55,6 +57,8 @@ class SimpleNotifierApp:
             self.api_config_provider = None
             self._handler_set_cache = {}
             logger.info("Event handler system disabled")
+
+        self._uvicorn_server: uvicorn.Server | None = None
     
     async def start(self):
         """Start the notifier application"""
@@ -65,9 +69,30 @@ class SimpleNotifierApp:
         # Start background tasks
         if self.batch_manager:
             asyncio.create_task(self._batch_recovery_loop())
-        
-        # Start main event processing loop
-        await self.subscriber.run(self.handle_event)
+
+        http_app = create_http_app(self)
+        uvicorn_config = uvicorn.Config(
+            http_app,
+            host=self.cfg.http_host,
+            port=self.cfg.http_port,
+            log_level=self.cfg.log_level.lower(),
+            access_log=False,
+        )
+        self._uvicorn_server = uvicorn.Server(uvicorn_config)
+        http_task = asyncio.create_task(self._uvicorn_server.serve())
+        logger.info(
+            "HTTP API listening on %s:%s (GET /status)",
+            self.cfg.http_host,
+            self.cfg.http_port,
+        )
+
+        try:
+            await self.subscriber.run(self.handle_event)
+        finally:
+            if self._uvicorn_server is not None:
+                self._uvicorn_server.should_exit = True
+            await http_task
+            self._uvicorn_server = None
     
     async def handle_event(self, subject: str, payload: Dict[str, Any]) -> bool:
         """
@@ -250,6 +275,8 @@ class SimpleNotifierApp:
     async def shutdown(self):
         """Graceful shutdown"""
         logger.info("Shutting down notifier application")
+        if self._uvicorn_server is not None:
+            self._uvicorn_server.should_exit = True
         try:
             await close_http_client()
         except Exception as e:

--- a/src/event-handler/requirements.txt
+++ b/src/event-handler/requirements.txt
@@ -3,3 +3,5 @@ PyYAML==6.0.3
 requests==2.33.0
 httpx==0.27.2
 nats-py==2.14.0
+fastapi==0.109.2
+uvicorn==0.27.1

--- a/src/event-handler/tests/test_config.py
+++ b/src/event-handler/tests/test_config.py
@@ -42,3 +42,8 @@ class TestNotifierConfig:
     def test_enable_event_handlers_default(self):
         cfg = NotifierConfig()
         assert isinstance(cfg.enable_event_handlers, bool)
+
+    def test_http_listen_defaults(self):
+        cfg = NotifierConfig()
+        assert cfg.http_host == "0.0.0.0"
+        assert cfg.http_port == 8000

--- a/src/event-handler/tests/test_http_api.py
+++ b/src/event-handler/tests/test_http_api.py
@@ -1,0 +1,64 @@
+"""Tests for the event-handler HTTP API."""
+
+import asyncio
+from unittest.mock import MagicMock
+
+import httpx
+
+from app.http_api import create_http_app
+
+
+def _mock_notifier(
+    *,
+    nats_connected: bool = True,
+    redis_ok: bool = True,
+    internal_key: str = "test-key",
+    handlers: bool = True,
+):
+    n = MagicMock()
+    if nats_connected:
+        n.subscriber.nc = MagicMock()
+        n.subscriber.nc.is_closed = False
+    else:
+        n.subscriber.nc = None
+    if redis_ok:
+        n.redis.ping = MagicMock(return_value=True)
+    else:
+        n.redis.ping = MagicMock(side_effect=OSError("redis down"))
+    n.cfg.internal_service_api_key = internal_key
+    n.cfg.enable_event_handlers = handlers
+    n.cfg.nats_stream = "EVENTS"
+    return n
+
+
+async def _get_status(app):
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        return await client.get("/status")
+
+
+def test_status_healthy():
+    app = create_http_app(_mock_notifier())
+    r = asyncio.run(_get_status(app))
+    assert r.status_code == 200
+    data = r.json()
+    assert data["status"] == "healthy"
+    assert data["service"] == "event-handler"
+    assert data["checks"]["nats"]["status"] == "ok"
+    assert data["checks"]["redis"]["status"] == "ok"
+
+
+def test_status_nats_down_returns_503():
+    app = create_http_app(_mock_notifier(nats_connected=False))
+    r = asyncio.run(_get_status(app))
+    assert r.status_code == 503
+    assert r.json()["status"] == "unhealthy"
+
+
+def test_status_redis_down_degraded():
+    app = create_http_app(_mock_notifier(redis_ok=False))
+    r = asyncio.run(_get_status(app))
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "degraded"
+    assert body["checks"]["redis"]["status"] == "error"

--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -24,4 +24,7 @@ ENV APP_VERSION=${APP_VERSION}
 
 COPY --from=build /app/build /usr/share/nginx/html
 
+# Serve GET /status via nginx (see frontend-nginx-config); bake semver into JSON
+RUN printf '{"status":"healthy","service":"frontend","version":"%s","checks":{"static":{"status":"ok"}}}\n' "$APP_VERSION" > /usr/share/nginx/html/status.json
+
 EXPOSE 80

--- a/src/frontend/public/status.json
+++ b/src/frontend/public/status.json
@@ -1,0 +1,8 @@
+{
+  "status": "healthy",
+  "service": "frontend",
+  "version": "dev",
+  "checks": {
+    "static": { "status": "ok" }
+  }
+}

--- a/src/frontend/src/App.js
+++ b/src/frontend/src/App.js
@@ -7,6 +7,7 @@ import { ThemeProvider } from './contexts/ThemeContext';
 import Navigation from './components/Navigation';
 import Login from './components/Login';
 import ProtectedRoute from './components/ProtectedRoute';
+import PublicHealthStatus from './components/PublicHealthStatus';
 import LoadingFallback from './components/LoadingFallback';
 
 // Lazy load all page components for better code splitting
@@ -89,6 +90,7 @@ function AppContent() {
             <Suspense fallback={<LoadingFallback />}>
               <Routes>
                 <Route path="/login" element={<Login />} />
+                <Route path="/status" element={<PublicHealthStatus />} />
                 <Route path="/change-password" element={
                   <ProtectedRoute>
                     <ChangePassword />

--- a/src/frontend/src/components/PublicHealthStatus.js
+++ b/src/frontend/src/components/PublicHealthStatus.js
@@ -1,0 +1,52 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Public /status for environments where the SPA handles the URL (CRA dev, or
+ * reverse proxies that send all paths to index.html). Fetches static status.json.
+ * Kubernetes/nginx should prefer serving GET /status as JSON before the SPA.
+ */
+function PublicHealthStatus() {
+  const [body, setBody] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const url = `${process.env.PUBLIC_URL || ''}/status.json`;
+    fetch(url)
+      .then((res) => {
+        if (!res.ok) throw new Error(res.statusText || String(res.status));
+        return res.json();
+      })
+      .then((data) => {
+        if (!cancelled) setBody(data);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e.message || 'fetch failed');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (error) {
+    return (
+      <pre style={{ margin: '1rem', whiteSpace: 'pre-wrap' }}>
+        {JSON.stringify(
+          { status: 'error', service: 'frontend', detail: error },
+          null,
+          2,
+        )}
+      </pre>
+    );
+  }
+  if (body === null) {
+    return <pre style={{ margin: '1rem' }}>Loading…</pre>;
+  }
+  return (
+    <pre style={{ margin: '1rem', whiteSpace: 'pre-wrap' }}>
+      {JSON.stringify(body, null, 2)}
+    </pre>
+  );
+}
+
+export default PublicHealthStatus;


### PR DESCRIPTION
Wire dependency-aware API /status (Postgres gates 503 by default, optional API_READINESS_STRICT), expose event-handler GET /status over uvicorn beside NATS, serve frontend /status JSON from nginx with a SPA fallback route, and add liveness/readiness (or startup where needed) for Postgres, Redis, NATS, ct-monitor, frontend, API, and event-handler.

Made-with: Cursor