### PR TITLE
chore(k8s): stage upgrade manifests and preserve cluster ingress host

### DIFF
--- a/reconhawx-k8s-common.sh
+++ b/reconhawx-k8s-common.sh
@@ -26,6 +26,11 @@
 #   (APP_VERSION — tied to release-please / cluster ConfigMap reconhawx-version).
 # - Locate kubernetes/base-update next to kubernetes/base (safe apply without
 #   re-applying jwt/postgres secrets from git).
+# - Sync frontend Ingress host in kubernetes/base from the cluster before upgrade apply
+#   so custom install hostnames are not overwritten by the repo default.
+# - From a git clone, copy kubernetes/base and kubernetes/base-update to
+#   INSTALL_STAGING_DIR (default /tmp/reconhawx) so patches do not dirty the repo;
+#   release trees apply from the extracted path in place.
 #
 # Usage
 # -----
@@ -35,6 +40,7 @@
 # The caller must define: die(), require_cmd(). If download path runs, it also
 # calls ui_step, ui_ok, ui_note — define those for consistent installer-style
 # output, or stub them if you need a silent/tooling caller.
+# Git staging paths also need read_installer() (and _B/_Z if you style prompts).
 #
 # Not runnable on its own (no main); do not execute directly.
 #
@@ -150,8 +156,86 @@ reconhawx_resolve_kubernetes_base_src() {
     reconhawx_download_release_kubernetes_base_set_BASE_SRC
   else
     [[ -d "$BASE_SRC" ]] || die "kubernetes/base not found at $BASE_SRC (use --from-release or RECONHAWX_FROM_RELEASE=1)"
-    RECONHAWX_INSTALL_FROM_RELEASE=0
     RECONHAWX_SOURCE_TREE_ROOT="$REPO_ROOT"
+    if [[ -e "$REPO_ROOT/.git" ]]; then
+      RECONHAWX_INSTALL_FROM_RELEASE=0
+    else
+      RECONHAWX_INSTALL_FROM_RELEASE=1
+    fi
+  fi
+}
+
+reconhawx_sync_directory_tree() {
+  local src="$1" dst="$2"
+  if command -v rsync &>/dev/null; then
+    mkdir -p "$dst"
+    rsync -a --delete "$src/" "$dst/"
+  else
+    rm -rf "$dst"
+    mkdir -p "$dst"
+    cp -a "$src"/. "$dst"/
+  fi
+}
+
+reconhawx_ensure_install_prefix() {
+  local root="$1"
+  if [[ -d "$root" ]] && [[ -w "$root" ]]; then
+    return 0
+  fi
+  local parent
+  parent="$(dirname "$root")"
+  if [[ -d "$parent" ]] && [[ -w "$parent" ]]; then
+    mkdir -p "$root/kubernetes/base" 2>/dev/null && return 0
+  fi
+  ui_note "Creating staging directory with sudo: $root"
+  sudo mkdir -p "$root/kubernetes"
+  sudo chown -R "$(id -u):$(id -g)" "$root"
+}
+
+# If staging_dir exists, prompt to remove (needs read_installer, ui_*, die, _B, _Z).
+reconhawx_staging_dir_prepare() {
+  local dir="$1"
+  if [[ ! -e "$dir" ]]; then
+    return 0
+  fi
+  ui_note "Upgrade staging path ${dir} already exists."
+  local ans
+  read_installer -r -p "$(printf '%supgrade · %s' "$_B" "Remove ${dir} and continue? [y/N] ")" ans
+  case "$ans" in
+  y | Y | yes | YES | Yes)
+    rm -rf "$dir"
+    ui_note "Removed ${dir}"
+    ;;
+  *)
+    die "Aborted: remove or rename ${dir} and re-run."
+    ;;
+  esac
+}
+
+# Copy kubernetes/base and kubernetes/base-update under staging_root; print new kubernetes/base path
+# on stdout only. Helpers here must not write ui_ok/ui_step to stdout (callers use BASE_SRC="$(…)").
+reconhawx_stage_kubernetes_upgrade_manifests() {
+  local repo_root="$1" staging_root="$2"
+  local dst_base="$staging_root/kubernetes/base" dst_up="$staging_root/kubernetes/base-update"
+  [[ -d "$repo_root/kubernetes/base-update" ]] || die "missing ${repo_root}/kubernetes/base-update"
+  reconhawx_staging_dir_prepare "$staging_root"
+  reconhawx_ensure_install_prefix "$staging_root"
+  mkdir -p "$staging_root/kubernetes"
+  # ui_note only: stdout must be only the path (callers use BASE_SRC="$(…)" ).
+  ui_note "Syncing upgrade manifests to ${staging_root} (git clone; removed after success)"
+  reconhawx_sync_directory_tree "$repo_root/kubernetes/base" "$dst_base"
+  reconhawx_sync_directory_tree "$repo_root/kubernetes/base-update" "$dst_up"
+  ui_note "Staged kubernetes/base and kubernetes/base-update"
+  printf '%s' "$dst_base"
+}
+
+reconhawx_update_staging_cleanup_on_success() {
+  local dir="${1:-}"
+  [[ -n "$dir" ]] || return 0
+  if [[ -e "$dir" ]]; then
+    ui_note "Removing upgrade staging directory ${dir} …"
+    rm -rf "$dir"
+    ui_note "Staging directory removed"
   fi
 }
 
@@ -161,6 +245,24 @@ reconhawx_base_update_dir() {
   upd="$(cd "$base_dir/.." && pwd)/base-update"
   [[ -d "$upd" ]] || die "missing ${upd} (kubernetes/base-update must sit next to kubernetes/base)"
   printf '%s' "$upd"
+}
+
+# Sync kubernetes/base/frontend/frontend-ingress.yaml host rule from the live Ingress so
+# upgrades do not re-apply a repo-default host (e.g. reconhawx.local) over a custom install.
+# Args: BASE_SRC (kubernetes/base path), namespace, then kubectl argv prefix (e.g. kubectl or
+# minikube -p PROFILE kubectl --). No-op if manifest or ingress is missing or host is empty.
+reconhawx_sync_frontend_ingress_manifest_from_cluster() {
+  local base_dir="$1" ns="$2" ing_file cluster_host otmp
+  shift 2
+  ing_file="$base_dir/frontend/frontend-ingress.yaml"
+  [[ -f "$ing_file" ]] || return 0
+  cluster_host="$("$@" get ingress frontend-ingress -n "$ns" -o jsonpath='{.spec.rules[0].host}' 2>/dev/null || true)"
+  cluster_host="$(printf '%s' "$cluster_host" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+  [[ -n "$cluster_host" ]] || return 0
+  otmp="$(mktemp)"
+  awk -v h="$cluster_host" '/^  - host: / { print "  - host: " h; next } { print }' "$ing_file" >"$otmp"
+  mv "$otmp" "$ing_file"
+  ui_note "frontend-ingress.yaml host synced from cluster: ${cluster_host}"
 }
 
 reconhawx_manifest_bundle_version() {

--- a/update-kubernetes.sh
+++ b/update-kubernetes.sh
@@ -156,6 +156,16 @@ require_cmd() {
   command -v "$1" &>/dev/null || die "missing required command: $1"
 }
 
+read_installer() {
+  if [[ -t 0 ]]; then
+    read "$@" || die "Unexpected end of input"
+  elif [[ -r /dev/tty ]]; then
+    read "$@" </dev/tty || die "Cannot read prompts (try saving this script and running bash update-kubernetes.sh)"
+  else
+    die "No TTY for prompts. Save the script and run: bash update-kubernetes.sh"
+  fi
+}
+
 usage() {
   cat <<'EOF'
 Usage: update-kubernetes.sh [options]
@@ -168,6 +178,7 @@ Environment:
   RECONHAWX_FROM_RELEASE   unset = auto (local kubernetes/base if present, else release).
   RECONHAWX_GITHUB_REPO    owner/repo (default: ReconHawx/reconhawx).
   RECONHAWX_NS             Namespace (default: reconhawx).
+  INSTALL_STAGING_DIR      Git clones only: copied manifests before apply (default: /tmp/reconhawx); removed after success.
 
 Inspect deployed manifest version:
   kubectl get configmap reconhawx-version -n reconhawx -o jsonpath='{.data.APP_VERSION}{"\n"}'
@@ -221,6 +232,13 @@ main() {
     ui_note "Cluster has no reconhawx-version ConfigMap yet (upgrade tracking starts after this release)."
   fi
 
+  local upgrade_staged=0 upgrade_stage_root=""
+  if [[ "${RECONHAWX_INSTALL_FROM_RELEASE:-0}" -eq 0 ]] && [[ -e "$REPO_ROOT/.git" ]]; then
+    upgrade_stage_root="${INSTALL_STAGING_DIR:-/tmp/reconhawx}"
+    BASE_SRC="$(reconhawx_stage_kubernetes_upgrade_manifests "$REPO_ROOT" "$upgrade_stage_root")"
+    upgrade_staged=1
+  fi
+
   local base_up
   base_up="$(reconhawx_base_update_dir "$BASE_SRC")"
 
@@ -228,6 +246,8 @@ main() {
   if [[ -n "${KUBECONFIG:-}" ]]; then
     ui_note "Using KUBECONFIG=${KUBECONFIG}"
   fi
+
+  reconhawx_sync_frontend_ingress_manifest_from_cluster "$BASE_SRC" "$RECONHAWX_NS" kubectl
 
   local _attempt _max=6
   for _attempt in $(seq 1 "$_max"); do
@@ -260,6 +280,9 @@ main() {
   ui_note "Inspect deployed manifest version: kubectl get configmap reconhawx-version -n ${RECONHAWX_NS} -o jsonpath='{.data.APP_VERSION}'"
   if [[ "${RECONHAWX_INSTALL_FROM_RELEASE:-0}" -eq 1 ]] && [[ -n "${RECONHAWX_SOURCE_TREE_ROOT:-}" ]]; then
     ui_note "Release source tree left at ${RECONHAWX_SOURCE_TREE_ROOT}"
+  fi
+  if [[ "$upgrade_staged" -eq 1 ]]; then
+    reconhawx_update_staging_cleanup_on_success "$upgrade_stage_root"
   fi
 }
 

--- a/update-minikube.sh
+++ b/update-minikube.sh
@@ -144,6 +144,16 @@ require_cmd() {
   command -v "$1" &>/dev/null || die "missing required command: $1"
 }
 
+read_installer() {
+  if [[ -t 0 ]]; then
+    read "$@" || die "Unexpected end of input"
+  elif [[ -r /dev/tty ]]; then
+    read "$@" </dev/tty || die "Cannot read prompts (try saving this script and running bash update-minikube.sh)"
+  else
+    die "No TTY for prompts. Save the script and run: bash update-minikube.sh"
+  fi
+}
+
 usage() {
   cat <<EOF
 Usage: update-minikube.sh [options]
@@ -157,6 +167,7 @@ Environment:
   RECONHAWX_FROM_RELEASE   unset = auto (local kubernetes/base if present, else release).
   RECONHAWX_GITHUB_REPO    owner/repo (default: ReconHawx/reconhawx).
   RECONHAWX_NS             Namespace (default: reconhawx).
+  INSTALL_STAGING_DIR      Git clones only: copied manifests before apply (default: /tmp/reconhawx); removed after success.
 EOF
 }
 
@@ -211,11 +222,20 @@ main() {
     ui_note "Cluster has no reconhawx-version ConfigMap yet (upgrade tracking starts after this release)."
   fi
 
+  local upgrade_staged=0 upgrade_stage_root=""
+  if [[ "${RECONHAWX_INSTALL_FROM_RELEASE:-0}" -eq 0 ]] && [[ -e "$REPO_ROOT/.git" ]]; then
+    upgrade_stage_root="${INSTALL_STAGING_DIR:-/tmp/reconhawx}"
+    BASE_SRC="$(reconhawx_stage_kubernetes_upgrade_manifests "$REPO_ROOT" "$upgrade_stage_root")"
+    upgrade_staged=1
+  fi
+
   local base_up
   base_up="$(reconhawx_base_update_dir "$BASE_SRC")"
 
   minikube_cluster_ok
   ui_note "Using minikube profile ${MINIKUBE_PROFILE}"
+
+  reconhawx_sync_frontend_ingress_manifest_from_cluster "$BASE_SRC" "$RECONHAWX_NS" minikube -p "$MINIKUBE_PROFILE" kubectl --
 
   local _attempt _max=6
   for _attempt in $(seq 1 "$_max"); do
@@ -246,6 +266,9 @@ main() {
   _ui_box_mid "$_G" "$_B" "Upgrade complete" "$_Z"
   _ui_box_bot "$_G" "$_Z"
   ui_note "Inspect deployed manifest version: minikube -p ${MINIKUBE_PROFILE} kubectl -- get configmap reconhawx-version -n ${RECONHAWX_NS} -o jsonpath='{.data.APP_VERSION}'"
+  if [[ "$upgrade_staged" -eq 1 ]]; then
+    reconhawx_update_staging_cleanup_on_success "$upgrade_stage_root"
+  fi
 }
 
 main


### PR DESCRIPTION
When upgrading from a git clone, copy kubernetes/base and kubernetes/base-update to INSTALL_STAGING_DIR (default /tmp/reconhawx) so applies do not modify the working tree; remove the staging tree after success. Sync frontend-ingress host from the live Ingress before apply so custom hostnames are not overwritten by the repo default. Treat trees without .git like release installs for RECONHAWX_INSTALL_FROM_RELEASE. Add read_installer so staging conflict prompts work with a TTY.

Made-with: Cursor