### PR TITLE
feat(auth): harden password change and admin reset options

### DIFF
--- a/src/api/app/models/user_postgres.py
+++ b/src/api/app/models/user_postgres.py
@@ -134,8 +134,12 @@ class UserUpdateRequest(BaseModel):
     must_change_password: Optional[bool] = None
 
 class PasswordChangeRequest(BaseModel):
-    """Password change request model"""
+    """Admin/superuser password reset request"""
     new_password: str = Field(..., min_length=4)
+    force_password_change: bool = Field(
+        default=False,
+        description="If true, user must change password on next login",
+    )
 
 class OwnPasswordChangeRequest(BaseModel):
     """Authenticated user changes their own password"""

--- a/src/api/app/repository/auth_repo.py
+++ b/src/api/app/repository/auth_repo.py
@@ -13,6 +13,11 @@ import bcrypt
 
 logger = logging.getLogger(__name__)
 DUMMY_HASH = bcrypt.hashpw(b"dummy password", bcrypt.gensalt()).decode()
+
+# Stable client-facing message; keep in sync with routes/auth.py ValueError → 400 mapping.
+PASSWORD_SAME_AS_CURRENT_MESSAGE = "New password must be different from the current password"
+
+
 class AuthRepository:
     """PostgreSQL repository for authentication and user management"""
     
@@ -331,14 +336,21 @@ class AuthRepository:
             logger.error(f"Error deleting user {user_id}: {str(e)}")
             raise
     
-    async def change_user_password(self, user_id: str, new_password: str) -> bool:
+    async def change_user_password(
+        self,
+        user_id: str,
+        new_password: str,
+        *,
+        force_password_change: bool = False,
+    ) -> bool:
         """
-        Change user password
-        
+        Change user password (admin reset).
+
         Args:
             user_id: User UUID string
             new_password: New plain text password
-            
+            force_password_change: When True, set must_change_password so the user must pick a new password at next login.
+
         Returns:
             True if password changed, False if user not found
         """
@@ -350,7 +362,7 @@ class AuthRepository:
                 
                 # Hash new password
                 user.password_hash = hash_password(new_password)
-                user.must_change_password = False
+                user.must_change_password = bool(force_password_change)
                 db.commit()
                 
                 return True
@@ -369,7 +381,7 @@ class AuthRepository:
         Change password for the authenticated user. Verifies current password.
         
         Raises:
-            ValueError: user not found or current password incorrect
+            ValueError: user not found, current password incorrect, or new password unchanged
         """
         try:
             async with get_db_session() as db:
@@ -378,6 +390,8 @@ class AuthRepository:
                     raise ValueError("User not found")
                 if not verify_password(current_password, user.password_hash):
                     raise ValueError("Invalid current password")
+                if verify_password(new_password, user.password_hash):
+                    raise ValueError(PASSWORD_SAME_AS_CURRENT_MESSAGE)
                 user.password_hash = hash_password(new_password)
                 user.must_change_password = False
                 db.commit()

--- a/src/api/app/routes/auth.py
+++ b/src/api/app/routes/auth.py
@@ -10,6 +10,7 @@ from models.user_postgres import (
 from auth.utils import generate_access_token, generate_refresh_token_value, REFRESH_TOKEN_EXPIRE_DAYS, ACCESS_TOKEN_EXPIRE_MINUTES
 from auth.dependencies import require_authentication, require_superuser
 from repository import AuthRepository
+from repository.auth_repo import PASSWORD_SAME_AS_CURRENT_MESSAGE
 import logging
 from datetime import datetime
 
@@ -137,7 +138,7 @@ async def change_own_password(
         return UserResponse(**updated)
     except ValueError as e:
         msg = str(e)
-        if msg == "Invalid current password":
+        if msg in ("Invalid current password", PASSWORD_SAME_AS_CURRENT_MESSAGE):
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=msg,
@@ -515,7 +516,11 @@ async def change_user_password(
             )
         
         # Change password
-        changed = await auth_repo.change_user_password(user_id, password_data.new_password)
+        changed = await auth_repo.change_user_password(
+            user_id,
+            password_data.new_password,
+            force_password_change=password_data.force_password_change,
+        )
         if not changed:
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/src/api/tests/test_password_change.py
+++ b/src/api/tests/test_password_change.py
@@ -8,6 +8,7 @@ import pytest
 from app.main import app
 from app.models.user_postgres import UserResponse
 from auth.dependencies import require_authentication
+from repository.auth_repo import PASSWORD_SAME_AS_CURRENT_MESSAGE
 
 
 def _user(**kwargs) -> UserResponse:
@@ -96,6 +97,30 @@ async def test_change_own_password_wrong_current(client: httpx.AsyncClient, over
             )
     assert response.status_code == 400
     assert "Invalid current password" in response.text
+
+
+@pytest.mark.asyncio
+async def test_change_own_password_same_as_current(client: httpx.AsyncClient, override_auth):
+    u = _user()
+    app.dependency_overrides[require_authentication] = lambda: u
+    with patch(
+        "routes.auth.AuthRepository",
+    ) as mock_cls:
+        mock_cls.return_value.change_own_password = AsyncMock(
+            side_effect=ValueError(PASSWORD_SAME_AS_CURRENT_MESSAGE)
+        )
+        with patch(
+            "middleware.auth.get_current_user",
+            new_callable=AsyncMock,
+            return_value=u,
+        ):
+            response = await client.post(
+                "/auth/me/password",
+                json={"current_password": "same", "new_password": "same"},
+                headers={"Authorization": "Bearer test-token"},
+            )
+    assert response.status_code == 400
+    assert PASSWORD_SAME_AS_CURRENT_MESSAGE in response.text
 
 
 @pytest.mark.asyncio

--- a/src/frontend/src/pages/admin/UserManagement.js
+++ b/src/frontend/src/pages/admin/UserManagement.js
@@ -69,7 +69,8 @@ function UserManagement() {
   
   const [passwordForm, setPasswordForm] = useState({
     new_password: '',
-    confirm_password: ''
+    confirm_password: '',
+    force_password_change: false,
   });
 
   const loadUsers = useCallback(async () => {
@@ -215,11 +216,19 @@ function UserManagement() {
       if (!userId) {
         throw new Error('User ID is missing');
       }
-      await userManagementAPI.changePassword(userId, passwordForm.new_password);
+      await userManagementAPI.changePassword(
+        userId,
+        passwordForm.new_password,
+        passwordForm.force_password_change,
+      );
       setSuccess('Password changed successfully');
       setShowPasswordModal(false);
       setSelectedUser(null);
-      setPasswordForm({ new_password: '', confirm_password: '' });
+      setPasswordForm({
+        new_password: '',
+        confirm_password: '',
+        force_password_change: false,
+      });
     } catch (err) {
       setError('Failed to change password: ' + (err.response?.data?.detail || err.message));
     } finally {
@@ -247,7 +256,11 @@ function UserManagement() {
 
   const openPasswordModal = (user) => {
     setSelectedUser(user);
-    setPasswordForm({ new_password: '', confirm_password: '' });
+    setPasswordForm({
+      new_password: '',
+      confirm_password: '',
+      force_password_change: false,
+    });
     setShowPasswordModal(true);
   };
 
@@ -908,6 +921,19 @@ function UserManagement() {
                 required
               />
             </Form.Group>
+
+            <Form.Check
+              type="checkbox"
+              id="reset-password-force-change"
+              label="Require password change on next login"
+              checked={passwordForm.force_password_change}
+              onChange={(e) =>
+                setPasswordForm({
+                  ...passwordForm,
+                  force_password_change: e.target.checked,
+                })
+              }
+            />
           </Modal.Body>
           <Modal.Footer>
             <Button variant="secondary" onClick={() => setShowPasswordModal(false)}>

--- a/src/frontend/src/services/api/admin.js
+++ b/src/frontend/src/services/api/admin.js
@@ -89,9 +89,10 @@ export const userManagementAPI = {
     return response.data;
   },
 
-  changePassword: async (userId, newPassword) => {
+  changePassword: async (userId, newPassword, forcePasswordChange = false) => {
     const response = await api.put(`/auth/users/${userId}/password`, {
-      new_password: newPassword
+      new_password: newPassword,
+      force_password_change: Boolean(forcePasswordChange),
     });
     return response.data;
   },


### PR DESCRIPTION
Block reusing the current password on POST /auth/me/password so forced change cannot be bypassed. Let admins optionally require a password change on next login when resetting another user's password.

Made-with: Cursor