### PR TITLE
docs(k8s): reorganize install docs

### DIFF
--- a/.cursor/rules/k8s-cluster-lifecycle.mdc
+++ b/.cursor/rules/k8s-cluster-lifecycle.mdc
@@ -1,0 +1,48 @@
+---
+globs:
+  - "install-kubernetes.sh"
+  - "install-minikube.sh"
+  - "update-kubernetes.sh"
+  - "update-minikube.sh"
+  - "uninstall-kubernetes.sh"
+  - "reconhawx-k8s-common.sh"
+  - "reconhawx-kueue-quota-sync.py"
+---
+
+# Cluster install / update / uninstall (ReconHawx user scripts)
+
+User-facing summaries live under **`docs/`**. This rule holds implementation detail for agents working on the repo-root lifecycle scripts.
+
+## Install manifest resolution
+
+**`install-kubernetes.sh`** / **`install-minikube.sh`**:
+
+- **Preferred user path:** unpacked **release source tarball** — uses **`kubernetes/base` in place** (extract dir or **`/tmp/reconhawx-release.*`** after script download).
+- **Directory with a `.git` subdirectory:** copies **`kubernetes/base`** into **`INSTALL_STAGING_DIR`** (default **`/tmp/reconhawx`**), writes generated secrets there, applies from staging; **deletes** staging after **success** (failed runs leave it for inspection). User must confirm if staging path already exists.
+- **`--from-release`** / **`RECONHAWX_FROM_RELEASE=1`**: force latest GitHub **source** tarball for manifests (see **`RECONHAWX_GITHUB_REPO`**).
+- After **`kubectl apply`**, **`reconhawx-kueue-quota-sync.py`** adjusts **ClusterQueue** `nominalQuota` to match nodes labeled **`reconhawx.runner`** / **`reconhawx.worker`** (requires **`python3`**). Documented from a user angle in **`kubernetes/README.md`**.
+
+Install scripts **do not** run SQL migrations; the API Deployment’s **`run-migrations`** init container does (see **`migrations.mdc`**).
+
+## Update scripts
+
+**`update-kubernetes.sh`** / **`update-minikube.sh`** apply **`kubernetes/base-update/`** (not full **`base`**) so **jwt-secret** / **postgres-secret** from the repo are not reapplied. They run **`kubernetes/base-update/pre-apply.d/*.sh`** in order, then **`kubectl apply -k kubernetes/base-update/`**, then **`kubectl rollout restart`** on **api**, **frontend**, **event-handler**, **ct-monitor**. **`RECONHAWX_KUEUE_RESYNC_QUOTAS=1`** runs **`reconhawx-kueue-quota-sync.py`** after apply.
+
+Pre-apply hook environment contract: **`.cursor/rules/k8s-kustomize-patterns.mdc`** (Pre-apply hooks section).
+
+## Uninstall script (`uninstall-kubernetes.sh`)
+
+**User flow:** detect **Kueue**, **ingress-nginx**, **MetalLB** (`metallb-system`); prompt once each (if detected) whether to remove; summarize; user types **`reconhawx`** to delete namespace **`reconhawx`**; remove cluster-scoped Kueue **ClusterQueue** / **ResourceFlavor** matching **`kubernetes/base/kueue`** defaults; optional full removals below.
+
+**Full Kueue removal** (when user opts in and nothing else needs Kueue): delete **`kueue.x-k8s.io`** custom resources, visibility **APIService**, **`v0.11.1`** release manifests (same URLs as install), namespace **`kueue-system`**, leftover **`*.kueue.x-k8s.io` CRDs**, clear namespace finalizers (**`jq`** helps). Deleting only **`kueue-system`** often **hangs** if webhooks/CRDs remain.
+
+**Full ingress-nginx removal** (cloud static manifest path): remove **ValidatingWebhookConfiguration** / **MutatingWebhookConfiguration** first (they block namespace teardown), **`kubectl delete -f`** using **`INGRESS_NGINX_DEPLOY_URL`** (default **`controller-v1.14.2`** cloud deploy), **IngressClass nginx**, optional **`ingressclassparams.networking.k8s.io`** CRD, matching **ClusterRole**/**ClusterRoleBinding**, namespace **`ingress-nginx`** with finalizer cleanup.
+
+**MetalLB:** delete namespace **`metallb-system`**.
+
+**Overrides:** **`INGRESS_NGINX_DEPLOY_URL`**, **`KUEUE_VERSION`**, **`KUEUE_MANIFESTS_URL`**, **`KUEUE_VISIBILITY_URL`** must match what was installed.
+
+## Related
+
+- **`kubernetes/README.md`** — Quick Start, upgrading, PostgreSQL StatefulSet migration notes.
+- **`docs/install-on-kubernetes.md`**, **`docs/uninstall-reconhawx.md`** — user docs.

--- a/.cursor/rules/k8s-kustomize-patterns.mdc
+++ b/.cursor/rules/k8s-kustomize-patterns.mdc
@@ -1,5 +1,9 @@
 ---
-globs: ["kubernetes/**/kustomization.yaml", "kubernetes/overlays/**/*.yaml"]
+globs:
+  - "kubernetes/**/kustomization.yaml"
+  - "kubernetes/overlays/**/*.yaml"
+  - "kubernetes/base-update/**/*.yaml"
+  - "kubernetes/base-update/pre-apply.d/**"
 ---
 
 # Kustomize Patterns and Conventions
@@ -372,3 +376,22 @@ kustomize build kubernetes/overlays/dev | kubectl apply --validate=true --dry-ru
      - ...existing...
      - {service}
    ```
+
+## Pre-apply hooks (`base-update`)
+
+Shell scripts in **`kubernetes/base-update/pre-apply.d/`** run **before** `kubectl apply -k kubernetes/base-update/` when using **`update-kubernetes.sh`** / **`update-minikube.sh`**. They are **not** Kustomize resources; they exist because **`kubectl apply` does not delete** objects removed from newer manifests.
+
+**Exported by the update scripts for hooks:**
+
+| Variable | Purpose |
+|----------|---------|
+| `RECONHAWX_NS` | Target namespace (default `reconhawx`). |
+| `RECONHAWX_CLUSTER_VERSION` | In-cluster **`reconhawx-version`** / **`APP_VERSION`**, or empty if missing. |
+| `RECONHAWX_BUNDLE_VERSION` | Semver from the bundle being applied. |
+| `RECONHAWX_PRE_APPLY_LIB` | Generated **`reconhawx_kubectl`** helper (see **`kubernetes/base-update/pre-apply.d/README.md`**). |
+
+Hooks may use **`sort -V`** on **`RECONHAWX_CLUSTER_VERSION`** / **`RECONHAWX_BUNDLE_VERSION`** for semver-gated behavior (see that README).
+
+**Manual upgrades:** run the same scripts **in lexicographic order** before `kubectl apply -k kubernetes/base-update/`. If a hook depends on version env vars, export **`RECONHAWX_CLUSTER_VERSION`** and **`RECONHAWX_BUNDLE_VERSION`** accordingly—see **`kubernetes/base-update/pre-apply.d/README.md`**.
+
+Install/update/uninstall **script** behavior: **`.cursor/rules/k8s-cluster-lifecycle.mdc`**.

--- a/.cursor/rules/migrations.mdc
+++ b/.cursor/rules/migrations.mdc
@@ -165,12 +165,40 @@ ADD CONSTRAINT fk_child_parent
 FOREIGN KEY (parent_id) REFERENCES parent_table(id) ON DELETE CASCADE;
 ```
 
+## Kubernetes runtime (API init container)
+
+Schema changes on cluster installs run **before** the API serves traffic:
+
+1. **`api` Deployment** init order: **`wait-for-postgresql`** (waits until **`pg_isready`** for the app DB so first-boot **`schema.sql`** finishes), then **`run-migrations`**.
+2. **`run-migrations`** uses the **`migrations`** image (`ghcr.io/<owner>/reconhawx/migrations`), built from **`src/migrations/`**.
+3. Connects via the **`postgresql`** Service using **`postgres-secret`** and **`database.name`** from **`service-config`**.
+
+**Default:** every pending **`V*__*.sql`** is **executed** (required when migrations contain DDL).
+
+**`MIGRATIONS_BASELINE_AUTOMARK=1`** (init-container env): use only when migration files are **bookkeeping** for a DB already fully created from **`kubernetes/base/postgresql/schema.sql`** and you intentionally do **not** want that SQL executed (dump-equivalent state). Leave **`0`** (Deployment default) for normal upgrades.
+
+If **`schema_migrations`** has rows for versions whose SQL never ran, fix by deleting those rows (e.g. `DELETE FROM schema_migrations WHERE version = '<version>';`) and restart the API Pod so **`run-migrations`** runs again.
+
+**Custom registry/tag:** keep aligned:
+
+- **`kubernetes/base/config/service-config.yaml`** — **`migrations.image`**
+- **`kubernetes/base/api/api-deployment.yaml`** — **`initContainers`** → **`run-migrations`** → **`image`**
+
+**Logs:**
+
+```bash
+kubectl logs -n reconhawx deploy/api -c run-migrations
+kubectl describe pod -n reconhawx -l app=api
+```
+
+**Off-cluster:** **`scripts/migrate.sh`** or **`python src/migrations/migrate.py`** with **`DATABASE_URL`**.
+
 ## References
 
 - Migration files: `src/migrations/V*.sql`
 - Migration CLI: `src/migrations/cli.py`
 - Migration runner: `src/migrations/migration_runner.py`
-- Kubernetes API init container: `src/migrations/k8s_entrypoint.py`, image `src/migrations/Dockerfile`, wired in `kubernetes/base/api/api-deployment.yaml` (optional `MIGRATIONS_BASELINE_AUTOMARK=1` only for dump-only bookkeeping; default runs all pending SQL)
+- Kubernetes API init container: `src/migrations/k8s_entrypoint.py`, image `src/migrations/Dockerfile`, wired in `kubernetes/base/api/api-deployment.yaml`
 - Shell wrapper: `scripts/migrate.sh`
 - SQLAlchemy models: `src/api/app/models/postgres.py`
 - Quick index (agents / contributors): `AGENTS.md` (repository root)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Use this file as a **first stop** for how the repo is laid out and how to run co
 | CT-Monitor | Certificate transparency log monitoring | [`src/ct-monitor/`](src/ct-monitor/) |
 | Event handler | Event consumers / handlers | [`src/event-handler/`](src/event-handler/) |
 | Migrations | PostgreSQL schema migrations (SQL + CLI) | [`src/migrations/`](src/migrations/) |
-| Kubernetes | Base manifests and Kueue (deploy with `kubectl apply -k kubernetes/base/`); upgrades: [`docs/update-reconhawx.md`](docs/update-reconhawx.md), `update-kubernetes.sh` / `update-minikube.sh` | [`kubernetes/`](kubernetes/) |
+| Kubernetes | Base manifests and Kueue (`kubectl apply -k kubernetes/base/`); user lifecycle: [`docs/install-on-kubernetes.md`](docs/install-on-kubernetes.md), [`docs/update-reconhawx.md`](docs/update-reconhawx.md), [`docs/uninstall-reconhawx.md`](docs/uninstall-reconhawx.md); scripts: [`.cursor/rules/k8s-cluster-lifecycle.mdc`](.cursor/rules/k8s-cluster-lifecycle.mdc) | [`kubernetes/`](kubernetes/) |
 
 ## Shell and devenv
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,12 @@ Supporting pieces include **PostgreSQL** for persistence, **NATS** (with JetStre
 
 ## Documentation and Setup
 
-- **[`docs/install-on-minikube.md`](docs/install-on-minikube.md)** — How to install on Minikube
-- **[`docs/install-on-kubernetes.md`](docs/install-on-kubernetes.md)** — How to install on a Kubernetes cluster
+Install and upgrade use manifests and scripts from a [**Source code** archive on GitHub Releases](https://github.com/ReconHawx/reconhawx/releases): download the archive for the version you want, extract it, and run the scripts from the top-level directory. See the install guides for details.
+
+- **[`docs/install-on-minikube.md`](docs/install-on-minikube.md)** — Install on Minikube
+- **[`docs/install-on-kubernetes.md`](docs/install-on-kubernetes.md)** — Install on a Kubernetes cluster
+- **[`docs/update-reconhawx.md`](docs/update-reconhawx.md)** — Upgrade an existing install
+- **[`docs/uninstall-reconhawx.md`](docs/uninstall-reconhawx.md)** — Remove ReconHawx from the cluster
 
 ## Credits
 

--- a/docs/install-on-kubernetes.md
+++ b/docs/install-on-kubernetes.md
@@ -1,52 +1,25 @@
 # Installation on Kubernetes
 
-For prerequisites, secrets, Kueue, ingress, and `kubectl apply -k kubernetes/base/`, follow **[`kubernetes/README.md`](../kubernetes/README.md)** first.
+## What you need
 
-You can install with the **[`install-kubernetes.sh`](../install-kubernetes.sh)** helper at the repo root or follow the manual steps below. The script stages manifests (`kubernetes/base`), labels nodes, installs Kueue and ingress-nginx, optionally MetalLB, and can update `/etc/hosts`. **It does not run SQL migrations**—those run in-cluster via the API Deployment’s **`run-migrations`** init container (see [Database migrations (automated)](#database-migrations-automated)).
+- A **Kubernetes cluster** and **`kubectl`** configured (`kubectl get nodes` works).
+- The **source code archive** for a ReconHawx release from [GitHub Releases](https://github.com/ReconHawx/reconhawx/releases), extracted on the machine where you run the installer (preferred). The top-level folder must contain **`kubernetes/base`** and **`install-kubernetes.sh`**.
+- **Nodes** you can label for **runner** and **worker** roles (one node can be both). The installer walks you through choosing them.
+- A way for your browser to resolve the **UI hostname** (default **`reconhawx.local`**; the installer can prompt for a **custom hostname** instead—then use that in **`/etc/hosts`** or DNS as usual).
 
-## Database migrations (automated)
+Full prerequisite detail (secrets layout, Kueue, ingress, manifest tree) is in **[`kubernetes/README.md`](../kubernetes/README.md)**.
 
-Schema changes are applied **inside the cluster** before the API pod serves traffic:
+## Recommended install
 
-1. The **`api` Deployment** defines init containers in order: **`wait-for-postgresql`** (retries until `pg_isready` succeeds for the app database — so first-boot `schema.sql` load finishes before migrations), then **`run-migrations`**.
-2. That container runs the **`migrations`** image (`ghcr.io/<owner>/reconhawx/migrations`), built from [`src/migrations/`](../src/migrations/).
-3. It connects to the **`postgresql`** Service using the same credentials as the API (`postgres-secret` + `database.name` from `service-config`).
-4. **By default**, every pending `V*__*.sql` file is **executed** against Postgres. This is required when migrations contain real DDL.
-
-   **Optional:** set init-container env **`MIGRATIONS_BASELINE_AUTOMARK=1`** only if your migration files are bookkeeping for a DB that was already fully created from [`kubernetes/base/postgresql/schema.sql`](../kubernetes/base/postgresql/schema.sql) and you intentionally do **not** want that SQL run (same state as the dump). Leave it **`0`** (default in the Deployment) for normal upgrades.
-
-   If wrong rows were inserted into `schema_migrations` without running SQL, remove them (e.g. `DELETE FROM schema_migrations WHERE version = '<version>';`) and restart the API pod so the init container runs again.
-
-To use a **custom registry or tag**, keep these aligned:
-
-- [`kubernetes/base/config/service-config.yaml`](../kubernetes/base/config/service-config.yaml) — key **`migrations.image`**
-- [`kubernetes/base/api/api-deployment.yaml`](../kubernetes/base/api/api-deployment.yaml) — **`initContainers`** → **`run-migrations`** → **`image`**
-
-**Logs and troubleshooting:**
-
-```bash
-kubectl logs -n reconhawx deploy/api -c run-migrations
-kubectl describe pod -n reconhawx -l app=api
-```
-
-If the init container fails, the API container does not start until the migration issue is fixed and the Deployment rolls again.
-
-**Local / CI outside the cluster:** you can still use [`scripts/migrate.sh`](../scripts/migrate.sh) or `python src/migrations/migrate.py` with `DATABASE_URL` (see [`AGENTS.md`](../AGENTS.md)).
-
-There are **two ways** to install ReconHawx on a generic Kubernetes cluster:
-
-1. **Installer script** — run [`install-kubernetes.sh`](../install-kubernetes.sh). It uses `kubectl` (and your current kubeconfig context). **Release / unpacked tarball** (no local `kubernetes/base`, or a tree **without** `.git` — e.g. manual GitHub source archive): uses `kubernetes/base` **in place** (downloaded extract under `/tmp/reconhawx-release.*`, or your unpack directory). **Git clone** (directory has `.git`): copies only `kubernetes/base` into **`/tmp/reconhawx`** (**`INSTALL_STAGING_DIR`**), writes secrets there, and deletes that staging dir after success. In all paths it labels nodes, installs Kueue and ingress-nginx, optionally MetalLB, and can update `/etc/hosts`. After manifests apply, it runs **[`reconhawx-kueue-quota-sync.py`](../reconhawx-kueue-quota-sync.py)** so **ClusterQueue** `nominalQuota` values match labeled-node capacity (see [`kubernetes/README.md`](../kubernetes/README.md#kueue-setup)). The installer requires **`python3`** for that step. Tarball **download** needs **`curl`**, **`tar`**, and **`jq`** or **`python3`** for the GitHub API.
-2. **Manual installation** — follow the commands below from [Set label on the nodes](#set-label-on-the-nodes) through [Test](#test).
-
-## Installer script
-
-From the repo root (with `kubectl` working against your cluster, e.g. `kubectl get nodes`):
+**Preferred:** on a machine with `kubectl` access to your cluster, download the **Source code** archive for the release you want from [GitHub Releases](https://github.com/ReconHawx/reconhawx/releases), extract it, `cd` into that top-level directory, and run:
 
 ```shell
 ./install-kubernetes.sh
 ```
 
-**Without cloning the repo** (script from `main`; pin a tag or SHA in the URL for reproducible installs):
+The installer expects **`kubernetes/base`** next to the script. It installs **Kueue**, **ingress-nginx**, optionally **MetalLB**, labels nodes, writes secrets under **`kubernetes/base`**, applies manifests, syncs **ClusterQueue** quotas (needs **`python3`**), and can update **`/etc/hosts`**.
+
+**Alternative:** run the installer script straight from GitHub (pin a **tag or SHA** in the URL for reproducibility). It can fetch the **latest release** tarball for you when you do not already have `kubernetes/base` locally. That path needs **`curl`**, **`tar`**, and **`jq`** or **`python3`** for the GitHub API.
 
 ```shell
 curl -fsSL https://raw.githubusercontent.com/ReconHawx/reconhawx/main/install-kubernetes.sh | bash
@@ -54,124 +27,69 @@ curl -fsSL https://raw.githubusercontent.com/ReconHawx/reconhawx/main/install-ku
 
 Piping into `bash` uses stdin for the script, so prompts are read from your **terminal** (`/dev/tty`). In headless environments, use `bash <(curl -fsSL …/install-kubernetes.sh)` or save the script and run `bash install-kubernetes.sh`.
 
-**In-place install** (release download **or** unpacked source tree with **no** `.git`): secrets and generated files are written under **`kubernetes/base` in that tree**; that directory is **not** deleted at the end.
+### Installer options
 
-**Git clone install** copies `kubernetes/base` to **`/tmp/reconhawx`** (override **`INSTALL_STAGING_DIR`**). If that staging path already exists, you confirm removal first; after a **successful** install it is **deleted** (failed runs leave it for inspection).
+| Input | Meaning |
+|--------|---------|
+| **`--from-release`** | Always use the **latest** published release tarball for manifests, even if you already have a local `kubernetes/base` directory. |
+| **`RECONHAWX_FROM_RELEASE`** | `1` = fetch release tarball; `0` = use the **`kubernetes/base`** next to the script; **unset** = use that directory when present, otherwise fetch a release. |
+| **`RECONHAWX_GITHUB_REPO`** | `owner/repo` for releases (default `ReconHawx/reconhawx`). |
 
-The script lists cluster nodes and asks you to choose **runner** and **worker** nodes (by name or by number from the list); a node may be both.
+## After install
 
-Options / environment:
+1. **Hostname** — The default UI hostname is **`reconhawx.local`**. The installer can prompt for a **custom hostname**; use whatever you entered. Ensure that name resolves (the script may have appended **`/etc/hosts`**). Otherwise point it at a node IP or load-balancer IP as in **[`kubernetes/README.md`](../kubernetes/README.md)**.
+2. Wait for core workloads:
 
-- **`--from-release`** — always use the latest published release tarball for manifests, even when run from a git tree.
-- **`RECONHAWX_FROM_RELEASE`** — `1` forces tarball, `0` forces local `kubernetes/base`, unset selects local when it exists and tarball otherwise.
-- **`RECONHAWX_GITHUB_REPO`** — `owner/repo` (default `ReconHawx/reconhawx`) for the releases API and tarball URL.
-- **`INSTALL_STAGING_DIR`** — **git clone installs only**: staging copy (default `/tmp/reconhawx`).
+   ```bash
+   kubectl wait deploy/frontend deploy/api -n reconhawx --for=condition=available --timeout=5m
+   ```
 
-## Upgrade (existing cluster)
+3. **Admin password** (first boot):
 
-Full upgrade procedure, troubleshooting, and manual steps: **[`docs/update-reconhawx.md`](update-reconhawx.md)**.
+   ```bash
+   kubectl logs statefulset/postgresql -n reconhawx | grep -A2 "ADMIN USER CREATED"
+   ```
 
-From a **git clone** or **extracted release tree** (not `curl | bash` alone), run:
+4. In a browser, open **`http://reconhawx.local`** or the **custom hostname** you set during install, and sign in as **`admin`** with that password.
 
-```shell
-./update-kubernetes.sh
+## Database migrations (automated)
+
+Schema updates run **inside the cluster** in the API Deployment’s **`run-migrations`** init container **before** the API serves traffic. You do not run SQL migrations manually for a normal install.
+
+If the API never becomes Ready after install or upgrade:
+
+```bash
+kubectl logs -n reconhawx deploy/api -c run-migrations
+kubectl describe pod -n reconhawx -l app=api
 ```
 
-Options match install semantics: **`--from-release`**, **`RECONHAWX_FROM_RELEASE`**, **`RECONHAWX_GITHUB_REPO`**.
+## Upgrades
 
-The script applies **[`kubernetes/base-update/`](../kubernetes/base-update/kustomization.yaml)** so **`jwt-secret`** and **`postgres-secret`** from the repo are **not** reapplied—avoiding accidental overwrite when upgrading from a fresh clone. It restarts **api**, **frontend**, **event-handler**, and **ct-monitor** so new container images roll out (API init runs **migrations** again).
-
-**Deployed manifest / app version** (semver aligned with release images):
-
-```shell
-kubectl get configmap reconhawx-version -n reconhawx -o jsonpath='{.data.APP_VERSION}{"\n"}'
-```
-
-That value is maintained in **[`kubernetes/base/config/reconhawx-version.yaml`](../kubernetes/base/config/reconhawx-version.yaml)** and bumped by release-please with **`version.txt`**.
+Use **[`docs/update-reconhawx.md`](update-reconhawx.md)** (`./update-kubernetes.sh` from an extracted release tree).
 
 ## Uninstall
 
-From the repo root, using the same kubeconfig context as for install:
+See **[`docs/uninstall-reconhawx.md`](uninstall-reconhawx.md)**.
 
-```shell
-./uninstall-kubernetes.sh
-```
+## Manual install (advanced)
 
-If you pipe the script (`curl … | bash`), prompts are read from your terminal (`/dev/tty`), same as for install.
-
-At the **start** of the run, the script **detects** whether **Kueue**, **ingress-nginx**, and **MetalLB** (`metallb-system`) appear to be installed and asks **once** for each (detected only) whether to remove them after ReconHawx. A short **summary** confirms your choices so you can leave the script unattended for the rest of the teardown.
-
-You then type **`reconhawx`** to confirm namespace deletion. The script deletes the **`reconhawx`** namespace, then removes the **cluster-scoped Kueue** `ClusterQueue` and `ResourceFlavor` objects that match [`kubernetes/base/kueue`](../kubernetes/base/kueue) defaults.
-
-If you chose **full Kueue** removal (recommended if nothing else on the cluster uses it), that path runs next and deletes **all** `kueue.x-k8s.io` custom resources, the visibility **APIService**, the **`v0.11.1`** release manifests (same URLs as install), namespace **`kueue-system`**, leftover **`*.kueue.x-k8s.io` CRDs**, and can clear namespace **finalizers** (install **`jq`** for that step). Only confirming **`kueue-system`** by itself often **hangs** because webhooks and CRDs remain.
-
-If you chose **full ingress-nginx** removal (recommended when you used the cloud static manifest in install), that path removes **Validating/MutatingWebhookConfiguration** objects first (they commonly block the namespace), runs **`kubectl delete -f`** on the same **`INGRESS_NGINX_DEPLOY_URL`** as install (default **`controller-v1.14.2`** cloud deploy), deletes **IngressClass nginx**, optional **`ingressclassparams.networking.k8s.io`** CRD, matching **ClusterRole(ClusterRoleBinding)**, then namespace **`ingress-nginx`** with **finalizer** cleanup. Override the URL with **`INGRESS_NGINX_DEPLOY_URL`** if your controller version differs.
-
-If you chose **MetalLB** removal, it deletes namespace **`metallb-system`**. You can still opt in at the end to removing **`reconhawx.runner`** / **`reconhawx.worker`** node labels. Remove **`reconhawx.local`** from `/etc/hosts` manually if you no longer need it.
-
-Override the Kueue manifest version with **`KUEUE_VERSION`** (and optionally **`KUEUE_MANIFESTS_URL`** / **`KUEUE_VISIBILITY_URL`**) if your install used a different release.
-
-## Prerequisites
-
-- Worker kubernetes cluster
-- Have kubectl installed
-- Have a KUBECONFIG file
-
-To test: `kubectl get nodes` should list nodes.
-
-## Manual Installation
-
-The sections below describe the **manual** procedure for reference or troubleshooting.
+Use this only if you are not using **`install-kubernetes.sh`**, typically from an **extracted release** directory so `kubernetes/base` paths match this documentation. For more context (Quick Start, image pins, Kueue overview), see **[`kubernetes/README.md`](../kubernetes/README.md)**. After the steps below, run **[`reconhawx-kueue-quota-sync.py`](../reconhawx-kueue-quota-sync.py)** so **ClusterQueue** quotas match labeled nodes (requires **`python3`**), unless you set quotas yourself.
 
 ### Set label on the nodes
 
-Determine which node will be the runner and the workers.
+**Runner** nodes run the control plane services (frontend, API, Postgres, NATS, Redis, event-handler, ct-monitor) and dispatch workflows. **Worker** nodes run recon tasks. A node may have both labels.
 
-#### Runner
-
-Runner nodes host backend services and run workflows to dispatch jobs to workers:
-
-- Frontend React App
-- API
-- Ct-Monitor
-- Event-Handler
-- Postgres
-- NATS
-- Redis
-
-#### Worker
-
-Worker nodes run recon tasks dispatched by the workflow.
-
-List the cluster nodes:
+List nodes, then label (replace names with your nodes):
 
 ```shell
 kubectl get nodes
 ```
-
-```
-NAME    STATUS   ROLES           AGE   VERSION
-k3s-1   Ready    control-plane   48d   v1.34.3+k3s3
-k3s-2   Ready    <none>          48d   v1.34.3+k3s3
-k3s-3   Ready    <none>          48d   v1.34.3+k3s3
-k3s-4   Ready    <none>          48d   v1.34.3+k3s3
-k3s-5   Ready    <none>          48d   v1.34.3+k3s3
-```
-
-Then apply the proper label on each node. A node can have both roles.
 
 ```shell
 kubectl label node k3s-2 reconhawx.runner=true
 kubectl label node k3s-3 reconhawx.worker=true
 kubectl label node k3s-4 reconhawx.worker=true
 kubectl label node k3s-5 reconhawx.worker=true
-```
-
-```
-node/k3s-2 labeled
-node/k3s-3 labeled
-node/k3s-4 labeled
-node/k3s-5 labeled
 ```
 
 ### Create a namespace for the reconhawx application
@@ -202,7 +120,7 @@ Before applying manifests that include an `Ingress`, ensure the validating webho
 kubectl get endpoints ingress-nginx-controller-admission -n ingress-nginx
 ```
 
-### Create Secrets Manifests
+### Create Secrets manifests
 
 ```shell
 # Copy example files
@@ -214,7 +132,7 @@ sed -i "s/JWT_SECRET_PLACEHOLDER/`echo -n \"$(openssl rand -hex 32)\" | base64 -
 sed -i "s/REFRESH_SECRET_KEY_PLACEHOLDER/`echo -n \"$(openssl rand -hex 32)\" | base64 -w0`/" kubernetes/base/secrets/jwt-secret.yaml
 sed -i "s/POSTGRES_PASSWORD_PLACEHOLDER/`echo -n \"$(openssl rand -hex 32)\" | base64 -w0`/" kubernetes/base/secrets/postgres-secret.yaml
 
-# Set Postgres Username (Using default "reconhawx")
+# Set Postgres username (default "reconhawx")
 sed -i "s/POSTGRES_USERNAME_PLACEHOLDER/cmVjb25oYXd4/" kubernetes/base/secrets/postgres-secret.yaml
 ```
 
@@ -224,9 +142,9 @@ sed -i "s/POSTGRES_USERNAME_PLACEHOLDER/cmVjb25oYXd4/" kubernetes/base/secrets/p
 kubectl apply -k kubernetes/base/
 ```
 
-After Postgres is up, the **API** pod’s **`run-migrations`** init container applies pending schema changes before `uvicorn` starts (see [Database migrations (automated)](#database-migrations-automated)).
+After Postgres is up, the API pod’s **`run-migrations`** init container applies pending schema before `uvicorn` starts (see [Database migrations (automated)](#database-migrations-automated)).
 
-### Wait for the postgresql pod to be ready and get admin password from the postgresql pod
+### Wait for PostgreSQL and read the admin password
 
 ```shell
 kubectl rollout status statefulset/postgresql -n reconhawx --timeout=5m
@@ -235,9 +153,9 @@ kubectl logs statefulset/postgresql -n reconhawx | grep -A2 "ADMIN USER CREATED"
 
 ### Set hosts file
 
-#### Using NodeIP
+#### Using node IP
 
-To reach your ReconHawx instance, the hostname `reconhawx.local` must resolve to the IP of one of the cluster's nodes.
+The UI hostname defaults to **`reconhawx.local`** (or whatever you configured in Ingress). It must resolve to a node IP (or LB IP) that reaches the ingress controller.
 
 ```shell
 echo "XX.XX.XX.XX reconhawx.local" | sudo tee -a /etc/hosts
@@ -245,15 +163,9 @@ echo "XX.XX.XX.XX reconhawx.local" | sudo tee -a /etc/hosts
 
 #### Using MetalLB (optional)
 
-To set a single IP for your ReconHawx instance, you can use MetalLB.
-
-Install MetalLB:
-
 ```shell
 kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.15.3/config/manifests/metallb-native.yaml
 ```
-
-Copy the MetalLB example configuration file and set an IP for MetalLB (`192.168.0.66` in this example):
 
 ```shell
 cp kubernetes/base/metal-lb/metal-lb.yaml.example kubernetes/base/metal-lb/metal-lb.yaml
@@ -261,7 +173,9 @@ sed -i 's/LB_IP_PLACEHOLDER/192\.168\.0\.66/g' kubernetes/base/metal-lb/metal-lb
 echo "192.168.0.66 reconhawx.local" | sudo tee -a /etc/hosts
 ```
 
-### Wait for API and Frontend healthy status
+Apply the edited MetalLB manifests as described in **[`kubernetes/README.md`](../kubernetes/README.md)** if they are not already part of your `kubectl apply -k kubernetes/base/` run.
+
+### Wait for API and frontend
 
 ```shell
 kubectl wait deploy/frontend deploy/api -n reconhawx --for=condition=available --timeout=5m
@@ -269,5 +183,5 @@ kubectl wait deploy/frontend deploy/api -n reconhawx --for=condition=available -
 
 ### Test
 
-- Browse http://reconhawx.local
-- Login with `admin` using the password retrieved from the Postgres logs
+- Open **`http://reconhawx.local`** (or your custom hostname) in a browser.
+- Log in as **`admin`** using the password from the PostgreSQL logs.

--- a/docs/install-on-minikube.md
+++ b/docs/install-on-minikube.md
@@ -1,52 +1,91 @@
-# Installation on minikube
+# Installation on Minikube
 
-There are **two ways** to install ReconHawx on Minikube:
+## What you need
 
-1. **Installer script** — run [`install-minikube.sh`](../install-minikube.sh) from the repo root. With **`kubernetes/base` and a `.git` directory** (git clone), it copies that tree to **`/tmp/reconhawx`** (**`INSTALL_STAGING_DIR`**) and removes it after a successful install. With **`kubernetes/base` but no `.git`** (typical unpacked release archive) or **without** a local tree, it uses manifests **in place** (your unpack dir or a downloaded extract under `/tmp/reconhawx-release.*`) — same rules as cluster [`install-kubernetes.sh`](../install-on-kubernetes.md). It generates secrets, starts or uses Minikube, applies the stack, runs **[`reconhawx-kueue-quota-sync.py`](../reconhawx-kueue-quota-sync.py)** to size **ClusterQueues** from labeled nodes (requires **`python3`**), and updates **`/etc/hosts`**. **It does not run SQL migrations**—the API Deployment’s **`run-migrations`** init container applies schema after Postgres is up (see [Database migrations (automated)](install-on-kubernetes.md#database-migrations-automated)). Piped installs (`curl … | bash`) read prompts from **`/dev/tty`**. Options: **`--from-release`**, **`--help`**, env **`RECONHAWX_FROM_RELEASE`**, **`RECONHAWX_GITHUB_REPO`**.
-2. **Manual installation** — run the commands yourself in order, starting at [Manual Installation](#manual-installation). You typically edit and apply `kubernetes/base` in your checkout (as in the snippets below).
+- **Minikube** installed.
+- The **source code archive** for a ReconHawx release from [GitHub Releases](https://github.com/ReconHawx/reconhawx/releases), extracted on the machine where you run the installer (preferred). The top-level folder must contain **`kubernetes/base`** and **`install-minikube.sh`**.
+- A machine where you can run shell scripts and edit **`/etc/hosts`** (the installer can set up your UI hostname; default **`reconhawx.local`**, or a **custom hostname** if you enter one).
 
-## Installer script
+Manifest and secret layout matches the generic install; see **[`kubernetes/README.md`](../kubernetes/README.md)** for reference.
 
-From the repo root:
+## Recommended install
+
+**Preferred:** download the **Source code** archive for the release you want from [GitHub Releases](https://github.com/ReconHawx/reconhawx/releases), extract it, `cd` into that top-level directory, and run:
 
 ```shell
 ./install-minikube.sh
 ```
 
-You are prompted for a **Minikube profile** name and secrets (JWT/refresh/Postgres). There is **no** separate “install root” prompt: **in-place** installs use the unpacked tree or `/tmp/reconhawx-release.*`; **git clone** installs stage under **`/tmp/reconhawx`** if needed, and you confirm before an existing staging path is replaced.
+You are prompted for a **Minikube profile** (default often **`reconhawx`**) and secrets. The script uses **`minikube … kubectl`** only (no separate **`kubectl`** binary required). It starts or reuses the profile, installs dependencies, applies manifests, syncs Kueue quotas (needs **`python3`**), and updates **`/etc/hosts`** as needed.
 
-The script uses **`minikube … kubectl` only** (no separate `kubectl` binary required). For troubleshooting migrations, use [`docs/install-on-kubernetes.md`](install-on-kubernetes.md#database-migrations-automated) or run [`scripts/migrate.sh`](../scripts/migrate.sh) locally with `DATABASE_URL` if you need to apply SQL outside the cluster.
+**Alternative:** run the installer script from GitHub (pin a **tag or SHA** for reproducibility). It can fetch the **latest release** tarball when you do not already have `kubernetes/base` locally.
 
-## Upgrade
+```shell
+curl -fsSL https://raw.githubusercontent.com/ReconHawx/reconhawx/main/install-minikube.sh | bash
+```
 
-See **[`docs/update-reconhawx.md`](update-reconhawx.md)** for the full procedure (versions, `base-update`, flags, troubleshooting).
+Piped installs read prompts from **`/dev/tty`**; for headless use, save the script and run `bash install-minikube.sh`.
 
-Quick path from the repo root: [`update-minikube.sh`](../update-minikube.sh) — applies **`kubernetes/base-update/`**, restarts app deployments, **`MINIKUBE_PROFILE`** default **`reconhawx`**. Options match [`update-kubernetes.sh`](../update-kubernetes.sh) / install (**`--from-release`**, **`RECONHAWX_FROM_RELEASE`**, etc.); overview: [Upgrade (existing cluster)](install-on-kubernetes.md#upgrade-existing-cluster).
+### Installer options
 
-## Manual Installation
+| Input | Meaning |
+|--------|---------|
+| **`--from-release`** | Always use the **latest** published release tarball for manifests, even if you already have a local `kubernetes/base` directory. |
+| **`--help`** | Show script usage. |
+| **`RECONHAWX_FROM_RELEASE`** | `1` = fetch release tarball; `0` = use the **`kubernetes/base`** next to the script; **unset** = use that directory when present, otherwise fetch a release. |
+| **`RECONHAWX_GITHUB_REPO`** | `owner/repo` for releases (default `ReconHawx/reconhawx`). |
 
-The sections below describe the **manual** procedure for reference or troubleshooting.
+## After install
+
+1. **Hostname** — The default UI hostname is **`reconhawx.local`**; the installer may prompt for a **custom hostname**. Ensure that name resolves (often via **`minikube ip`**); the script may have updated **`/etc/hosts`**.
+2. Wait for the API and frontend:
+
+   ```shell
+   minikube -p reconhawx kubectl -- wait deploy/frontend deploy/api -n reconhawx --for=condition=available --timeout=5m
+   ```
+
+   Use your profile name in place of **`reconhawx`** if different.
+
+3. **Admin password**:
+
+   ```shell
+   minikube -p reconhawx kubectl -- logs statefulset/postgresql -n reconhawx | grep -A2 "ADMIN USER CREATED"
+   ```
+
+4. In a browser, open **`http://reconhawx.local`** or the **custom hostname** you set during install, and sign in as **`admin`**.
+
+## Database migrations (automated)
+
+Same as on a full cluster: the API **`run-migrations`** init container applies schema before traffic. If the API stays not Ready:
+
+```shell
+minikube -p reconhawx kubectl -- logs -n reconhawx deploy/api -c run-migrations
+```
+
+See **[Database migrations (automated)](install-on-kubernetes.md#database-migrations-automated)** on the cluster install page.
+
+## Upgrades
+
+See **[`docs/update-reconhawx.md`](update-reconhawx.md)**. From the repo root:
+
+```shell
+./update-minikube.sh
+```
+
+Default profile is **`reconhawx`**. Override with **`MINIKUBE_PROFILE=my-profile`**.
+
+## Uninstall
+
+See **[`docs/uninstall-reconhawx.md`](uninstall-reconhawx.md)** (script or **`minikube delete -p …`**).
+
+## Manual install (advanced)
+
+Use this only if you are not using **`install-minikube.sh`**, typically from an **extracted release** directory so `kubernetes/base` paths match this documentation. Replace **`reconhawx`** with your Minikube profile name if different. After the steps below, run **[`reconhawx-kueue-quota-sync.py`](../reconhawx-kueue-quota-sync.py)** with **`python3`** unless you set ClusterQueues manually. For manifest context, see **[`kubernetes/README.md`](../kubernetes/README.md)**.
 
 ### Install and start minikube
 
 ```shell
 minikube -p reconhawx start --driver=docker --ports=80:80 --ports=443:443
-```
-```shell
-😄  [reconhawx] minikube v1.38.1 on Nixos 26.05
-    ▪ MINIKUBE_WANTUPDATENOTIFICATION=false
-✨  Automatically selected the docker driver. Other choices: kvm2, ssh
-❗  Starting v1.39.0, minikube will default to "containerd" container runtime. See #21973 for more info.
-📌  Using Docker driver with root privileges
-👍  Starting "reconhawx" primary control-plane node in "reconhawx" cluster
-🚜  Pulling base image v0.0.50 ...
-🔥  Creating docker container (CPUs=2, Memory=7900MB) ...
-🐳  Preparing Kubernetes v1.35.1 on Docker 29.2.1 ...
-🔗  Configuring bridge CNI (Container Networking Interface) ...
-🔎  Verifying Kubernetes components...
-    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
-🌟  Enabled addons: storage-provisioner, default-storageclass
-🏄  Done! kubectl is now configured to use "reconhawx" cluster and "default" namespace by default
 ```
 
 ### Set label on the minikube node
@@ -56,13 +95,15 @@ minikube -p reconhawx kubectl -- label node reconhawx reconhawx.runner=true
 minikube -p reconhawx kubectl -- label node reconhawx reconhawx.worker=true
 ```
 
+If your node name is not **`reconhawx`**, use the name from `minikube -p reconhawx kubectl -- get nodes`.
+
 ### Create a namespace for the reconhawx application
 
 ```shell
 minikube -p reconhawx kubectl -- create namespace reconhawx
 ```
 
-### Install kueue on the minikube cluster
+### Install Kueue on the minikube cluster
 
 ```shell
 minikube -p reconhawx kubectl -- apply --server-side -f https://github.com/kubernetes-sigs/kueue/releases/download/v0.11.1/manifests.yaml
@@ -78,13 +119,13 @@ minikube -p reconhawx kubectl -- wait deploy/ingress-nginx-controller -n ingress
 minikube -p reconhawx kubectl -- rollout status deployment/ingress-nginx-controller -n ingress-nginx --timeout=5m
 ```
 
-Before applying manifests that include an `Ingress`, ensure the validating webhook can be reached (`validate.nginx.ingress.kubernetes.io`). If `kubectl apply` fails with `connection refused` to `ingress-nginx-controller-admission`, wait until that Service has endpoints, then retry after a short pause (or run [`install-minikube.sh`](../install-minikube.sh), which waits and retries):
+Before applying manifests that include an `Ingress`, ensure the validating webhook can be reached. If `kubectl apply` fails with `connection refused` to `ingress-nginx-controller-admission`, wait until that Service has endpoints, then retry (or run [`install-minikube.sh`](../install-minikube.sh), which waits and retries):
 
 ```shell
 minikube -p reconhawx kubectl -- get endpoints ingress-nginx-controller-admission -n ingress-nginx
 ```
 
-### Create Secrets Manifests
+### Create Secrets manifests
 
 ```shell
 # Copy example files
@@ -96,7 +137,7 @@ sed -i "s/JWT_SECRET_PLACEHOLDER/`echo -n \"$(openssl rand -hex 32)\" | base64 -
 sed -i "s/REFRESH_SECRET_KEY_PLACEHOLDER/`echo -n \"$(openssl rand -hex 32)\" | base64 -w0`/" kubernetes/base/secrets/jwt-secret.yaml
 sed -i "s/POSTGRES_PASSWORD_PLACEHOLDER/`echo -n \"$(openssl rand -hex 32)\" | base64 -w0`/" kubernetes/base/secrets/postgres-secret.yaml
 
-# Set Postgres Username (Using default "reconhawx")
+# Set Postgres username (default "reconhawx")
 sed -i "s/POSTGRES_USERNAME_PLACEHOLDER/cmVjb25oYXd4/" kubernetes/base/secrets/postgres-secret.yaml
 ```
 
@@ -106,26 +147,28 @@ sed -i "s/POSTGRES_USERNAME_PLACEHOLDER/cmVjb25oYXd4/" kubernetes/base/secrets/p
 minikube -p reconhawx kubectl -- apply -k kubernetes/base/
 ```
 
-### Wait for the postgresql pod to be ready and get admin password from the postgresql pod
+### Wait for PostgreSQL and read the admin password
 
 ```shell
 minikube -p reconhawx kubectl -- rollout status statefulset/postgresql -n reconhawx --timeout=5m
 minikube -p reconhawx kubectl -- logs statefulset/postgresql -n reconhawx | grep -A2 "ADMIN USER CREATED"
 ```
 
-### Get Ingress IP and set hosts file
+### Get ingress IP and set hosts file
 
 ```shell
 echo "$(minikube -p reconhawx ip) reconhawx.local" | sudo tee -a /etc/hosts
 ```
 
-### Wait for API and Frontend healty status
+Use your **custom hostname** in place of **`reconhawx.local`** if you configured one in Ingress.
+
+### Wait for API and frontend
 
 ```shell
-minikube -p reconhawx kubectl -- wait deploy/frontend deploy/api -n reconhawx --for=condition=available --timeout=5
+minikube -p reconhawx kubectl -- wait deploy/frontend deploy/api -n reconhawx --for=condition=available --timeout=5m
 ```
 
 ### Test
 
-- Browse http://reconhawx.local
-- Login with "admin" using the password retrieved from the Postgres logs
+- Open **`http://reconhawx.local`** (or your custom hostname) in a browser.
+- Log in as **`admin`** using the password from the PostgreSQL logs.

--- a/docs/uninstall-reconhawx.md
+++ b/docs/uninstall-reconhawx.md
@@ -1,0 +1,52 @@
+# Uninstalling ReconHawx
+
+This guide removes ReconHawx from a **Kubernetes cluster** (including a cluster created by **Minikube**) after a normal install.
+
+For first-time install, see **[`docs/install-on-kubernetes.md`](install-on-kubernetes.md)** or **[`docs/install-on-minikube.md`](install-on-minikube.md)**.
+
+## Kubernetes cluster (recommended)
+
+From the **top-level directory of your extracted release** (where **`uninstall-kubernetes.sh`** lives), with the same kubeconfig context you used for install:
+
+```shell
+./uninstall-kubernetes.sh
+```
+
+**Only the script** (script from `main`; pin a tag or SHA in the URL for reproducible teardown):
+
+```shell
+curl -fsSL https://raw.githubusercontent.com/ReconHawx/reconhawx/main/uninstall-kubernetes.sh | bash
+```
+
+Piping into `bash` uses stdin for the script, so prompts are read from your **terminal** (`/dev/tty`). For headless use, save the script and run it with `bash`, or use process substitution as in the install docs.
+
+### What you will be asked
+
+1. **Shared infrastructure** — If **Kueue**, **ingress-nginx**, or **MetalLB** (`metallb-system`) look like they were installed for this setup, the script asks **once per component** whether to remove them after ReconHawx. Choose **no** if other workloads on the cluster still need them.
+2. **Namespace** — You type **`reconhawx`** to confirm deleting the **`reconhawx`** namespace and ReconHawx-scoped resources.
+3. **Optional cleanup** — You may be offered removal of **`reconhawx.runner`** / **`reconhawx.worker`** node labels if you no longer need them.
+
+Remove **`reconhawx.local`** from **`/etc/hosts`** yourself if you added it during install.
+
+### Overrides (optional)
+
+If your install used non-default URLs or versions, set the same variables the installer respected:
+
+- **`INGRESS_NGINX_DEPLOY_URL`** — Ingress controller manifest URL (must match what you installed) if you remove ingress-nginx.
+- **`KUEUE_VERSION`**, and optionally **`KUEUE_MANIFESTS_URL`** / **`KUEUE_VISIBILITY_URL`** — If your Kueue install differed from the default release.
+
+## Minikube-only shortcut
+
+If this Minikube **profile exists only for ReconHawx**, you can delete the whole cluster:
+
+```shell
+minikube delete -p reconhawx
+```
+
+(Use the profile name you chose at install; default is often `reconhawx`.)
+
+If the profile runs **other** workloads, use **`./uninstall-kubernetes.sh`** with `kubectl` pointed at that profile instead (for example `minikube -p my-profile kubectl` as your `kubectl` wrapper, or the kubeconfig Minikube prints), so you only remove ReconHawx resources.
+
+## Related documentation
+
+- **[`docs/update-reconhawx.md`](update-reconhawx.md)** — upgrades (not uninstall).

--- a/docs/update-reconhawx.md
+++ b/docs/update-reconhawx.md
@@ -8,7 +8,7 @@ Upgrades are different from install: they do **not** reinstall Kueue, ingress-ng
 
 | Requirement | Notes |
 |-------------|--------|
-| **Repository tree** | A **git clone** or an **extracted GitHub release source tarball** (full tree: `kubernetes/base`, `kubernetes/base-update`, `reconhawx-k8s-common.sh` at repo root). `curl \| bash` against only `install-kubernetes.sh` is **not** enough for updates—you need these files on disk. |
+| **Release tree on disk** | **Preferred:** extract the **Source code** archive from [GitHub Releases](https://github.com/ReconHawx/reconhawx/releases). You need `kubernetes/base`, `kubernetes/base-update`, and the update scripts at the **top level** (e.g. `update-kubernetes.sh`, `reconhawx-k8s-common.sh`). Running `curl \| bash` on the install script alone is **not** enough for updates—you need that tree on disk (or let the update script fetch a tarball—see flags below). |
 | **`kubectl`** (generic cluster) | Same kubeconfig / context you used for install. |
 | **`minikube`** (Minikube) | Update script uses `minikube … kubectl`; no standalone `kubectl` required. |
 | **`curl`** | Used to query GitHub `releases/latest` and to download release tarballs when you opt into the release path. |
@@ -32,7 +32,7 @@ If that ConfigMap does not exist yet, the cluster predates this mechanism; runni
 
 ## Recommended: helper scripts
 
-Run from the **repository root** (where `reconhawx-k8s-common.sh` and the update script live).
+Run from the **top-level directory of your extracted release** (where `reconhawx-k8s-common.sh` and the update script live).
 
 ### Generic Kubernetes
 
@@ -54,10 +54,10 @@ MINIKUBE_PROFILE=my-profile ./update-minikube.sh
 
 ### What the scripts do
 
-1. **Resolve manifests** — Either use **`kubernetes/base`** next to your clone (default when the directory exists) or download the **latest GitHub release** source tarball (same logic as install: see flags below).
+1. **Resolve manifests** — Use **`kubernetes/base`** next to the script when that directory exists, or download the **latest GitHub release** source tarball (same logic as install: see flags below).
 2. **Print version context** — Manifest **`APP_VERSION`**, GitHub **latest release tag**, and in-cluster **`reconhawx-version`** when present.
-3. **Pre-apply hooks** — Run shell scripts in **[`kubernetes/base-update/pre-apply.d/`](../kubernetes/base-update/pre-apply.d/)** (if any) **before** applying manifests. They perform idempotent cluster fixups—for example removing a workload replaced by a different controller kind. See [Pre-apply hooks](#pre-apply-hooks) below.
-4. **Apply** — `kubectl apply -k` on **[`kubernetes/base-update/`](../kubernetes/base-update/kustomization.yaml)** (not full `kubernetes/base/`). The **update** overlay applies the same workloads and config as `base` but **omits** `jwt-secret` and `postgres-secret` from the repo so a fresh clone does **not** overwrite live database or signing secrets. It includes **[`kubernetes/base/kueue/core`](../kubernetes/base/kueue/core/kustomization.yaml)** (flavors, local queues, RBAC) but **not** the **ClusterQueue** manifests under [`kubernetes/base/kueue/cluster-queues/`](../kubernetes/base/kueue/cluster-queues/kustomization.yaml), so upgrades **do not reset** cluster-sized `nominalQuota` values. To recompute quotas after scaling nodes, run **`RECONHAWX_KUEUE_RESYNC_QUOTAS=1 ./update-kubernetes.sh`** (or **`update-minikube.sh`**) from a tree that contains [`reconhawx-kueue-quota-sync.py`](../reconhawx-kueue-quota-sync.py), or invoke that script manually.
+3. **Pre-apply hooks** — Run shell scripts in **[`kubernetes/base-update/pre-apply.d/`](../kubernetes/base-update/pre-apply.d/)** (if any) **before** applying manifests. They perform idempotent cluster fixups—for example removing a workload replaced by a different controller kind. Authors: see [`kubernetes/base-update/pre-apply.d/README.md`](../kubernetes/base-update/pre-apply.d/README.md).
+4. **Apply** — `kubectl apply -k` on **[`kubernetes/base-update/`](../kubernetes/base-update/kustomization.yaml)** (not full `kubernetes/base/`). The **update** overlay applies the same workloads and config as `base` but **omits** `jwt-secret` and `postgres-secret` from the bundle so applying an **unpacked release** does **not** overwrite live database or signing secrets with example files. It includes **[`kubernetes/base/kueue/core`](../kubernetes/base/kueue/core/kustomization.yaml)** (flavors, local queues, RBAC) but **not** the **ClusterQueue** manifests under [`kubernetes/base/kueue/cluster-queues/`](../kubernetes/base/kueue/cluster-queues/kustomization.yaml), so upgrades **do not reset** cluster-sized `nominalQuota` values. To recompute quotas after scaling nodes, run **`RECONHAWX_KUEUE_RESYNC_QUOTAS=1 ./update-kubernetes.sh`** (or **`update-minikube.sh`**) from a directory that contains [`reconhawx-kueue-quota-sync.py`](../reconhawx-kueue-quota-sync.py), or invoke that script manually.
 5. **Roll out** — `kubectl rollout restart` for **api**, **frontend**, **event-handler**, and **ct-monitor**, then wait for rollouts to finish.
 
 Restarting **api** creates a new Pod: the **`run-migrations`** init container runs again with the **migrations** image for the target release, then the API container starts. If migrations fail, the API Pod will not become Ready until the issue is fixed—see [Database migrations (automated)](install-on-kubernetes.md#database-migrations-automated).
@@ -67,7 +67,7 @@ Restarting **api** creates a new Pod: the **`run-migrations`** init container ru
 | Input | Meaning |
 |--------|---------|
 | **`--from-release`** | Always use the latest published release tarball for manifests, even if you have a local `kubernetes/base`. |
-| **`RECONHAWX_FROM_RELEASE`** | `1` = force release tarball; `0` = force local `kubernetes/base`; **unset** = use local tree when `kubernetes/base` exists, otherwise download release. |
+| **`RECONHAWX_FROM_RELEASE`** | `1` = force release tarball; `0` = force local `kubernetes/base`; **unset** = use the directory next to the script when `kubernetes/base` exists, otherwise download release. |
 | **`RECONHAWX_GITHUB_REPO`** | `owner/repo` for releases API and tarball (default `ReconHawx/reconhawx`). Use your fork if images and releases live there. |
 | **`RECONHAWX_NS`** | Namespace (default `reconhawx`). |
 | **`RECONHAWX_KUEUE_RESYNC_QUOTAS`** | Set to **`1`** to run [`reconhawx-kueue-quota-sync.py`](../reconhawx-kueue-quota-sync.py) after a successful apply (needs **`python3`**). |
@@ -79,30 +79,13 @@ Script help:
 ./update-minikube.sh --help
 ```
 
-## Pre-apply hooks
-
-Scripts in [`kubernetes/base-update/pre-apply.d/`](../kubernetes/base-update/pre-apply.d/) run **automatically** (step 3 above) **before** `kubectl apply -k kubernetes/base-update/`. They are **not** part of Kustomize; they exist because **`kubectl apply` does not delete** API objects that were removed from newer manifests.
-
-The update scripts export:
-
-| Variable | Purpose |
-|----------|---------|
-| `RECONHAWX_NS` | Target namespace (default `reconhawx`). |
-| `RECONHAWX_CLUSTER_VERSION` | In-cluster `reconhawx-version` / `APP_VERSION`, or empty if missing. |
-| `RECONHAWX_BUNDLE_VERSION` | Semver from the bundle being applied. |
-| `RECONHAWX_PRE_APPLY_LIB` | Generated `reconhawx_kubectl` helper (see [`pre-apply.d/README.md`](../kubernetes/base-update/pre-apply.d/README.md)). |
-
-Hooks can use **`sort -V`** on those strings for semver-gated behavior (documented in that README).
-
-**Manual upgrades:** if you do not use `./update-kubernetes.sh` or `./update-minikube.sh`, run the same scripts **in lexicographic order** before applying manifests—see the manual example in [`pre-apply.d/README.md`](../kubernetes/base-update/pre-apply.d/README.md)—and export `RECONHAWX_CLUSTER_VERSION` / `RECONHAWX_BUNDLE_VERSION` when a hook relies on them.
-
 ## Manual upgrade (without scripts)
 
 Equivalent high-level steps:
 
-1. Obtain a tree whose **`kubernetes/base`** matches the release you want (checkout tag, or extract release tarball).
-2. Run **pre-apply hooks** (if present) in order—see [Pre-apply hooks](#pre-apply-hooks) and [`kubernetes/base-update/pre-apply.d/README.md`](../kubernetes/base-update/pre-apply.d/README.md).
-3. Apply the safe overlay (no secrets from git):
+1. Obtain an unpacked release whose **`kubernetes/base`** matches the version you want (download the **Source code** archive for that release from GitHub and extract it).
+2. Run **pre-apply hooks** (if present) in lexicographic order—see [`kubernetes/base-update/pre-apply.d/README.md`](../kubernetes/base-update/pre-apply.d/README.md).
+3. Apply the safe overlay (does not re-apply Secret manifests from the bundle):
 
    ```bash
    kubectl apply -k kubernetes/base-update/
@@ -120,11 +103,11 @@ You still need **`curl` / GitHub** only if you choose to fetch a tarball yoursel
 
 ## Why `base-update` instead of `base`?
 
-[`kubernetes/base/`](../kubernetes/base/kustomization.yaml) includes Secret manifests under **`kubernetes/base/secrets/`**. Those files in git are **examples or local dev** values. Running `kubectl apply -k kubernetes/base/` from a **new** clone can **replace** cluster Secrets and break login or database access.
+[`kubernetes/base/`](../kubernetes/base/kustomization.yaml) includes Secret manifests under **`kubernetes/base/secrets/`**. Those files ship as **examples** in the release tree. Running `kubectl apply -k kubernetes/base/` from a **fresh** unpacked release can **replace** cluster Secrets and break login or database access.
 
 [`kubernetes/base-update/`](../kubernetes/base-update/kustomization.yaml) applies the same ConfigMaps, Deployments, RBAC, Kueue flavors/local queues/RBAC, etc., but **does not** apply those Secret objects. Existing cluster Secrets are left unchanged. **ClusterQueue** objects are also **not** part of the update bundle (see step 4 above), so their quotas stay as last set by install or [`reconhawx-kueue-quota-sync.py`](../reconhawx-kueue-quota-sync.py).
 
-If you intentionally need to rotate Secrets from files, do that with a controlled process (e.g. `kubectl apply` specific Secret YAMLs you generated securely), not by blindly applying full `base` from an unchecked-in tree.
+If you intentionally need to rotate Secrets from files, do that with a controlled process (e.g. `kubectl apply` specific Secret YAMLs you generated securely), not by blindly applying full `base` from an unmodified release extract.
 
 ## Troubleshooting
 
@@ -147,7 +130,8 @@ Set `KUBECONFIG` and context; use `RECONHAWX_NS` if you deploy to a non-default 
 
 ## Related documentation
 
-- [Installation on Kubernetes](install-on-kubernetes.md) — first-time install, migrations, manual steps.
-- [Installation on Minikube](install-on-minikube.md) — Minikube install and profile notes.
+- [Installation on Kubernetes](install-on-kubernetes.md) — first-time install.
+- [Installation on Minikube](install-on-minikube.md) — Minikube install.
+- [Uninstalling ReconHawx](uninstall-reconhawx.md) — remove from cluster or Minikube.
 - [`kubernetes/README.md`](../kubernetes/README.md) — base layout, images, Kueue overview.
 - [`AGENTS.md`](../AGENTS.md) — repo map and operational pointers.

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -42,7 +42,7 @@ Use repo root **`update-kubernetes.sh`** or **`update-minikube.sh`**, or manuall
 
 Manifests run PostgreSQL as a **StatefulSet** with a **headless** Service (`postgresql-headless`) for pod identity and the existing **NodePort** Service `postgresql` for clients. If the cluster still has **`deployment.apps/postgresql`** from an older release, do **not** apply the StatefulSet while that Deployment is running: both select `app=postgresql`, so the Service could send traffic to two Postgres instances.
 
-**Preferred:** run **`./update-kubernetes.sh`** or **`./update-minikube.sh`** from the release you are upgrading to. Pre-apply hooks in [`base-update/pre-apply.d/`](base-update/pre-apply.d/) drop the legacy Deployment and wait for pods to exit before `kubectl apply`. See **[`docs/update-reconhawx.md`](../docs/update-reconhawx.md#pre-apply-hooks)**.
+**Preferred:** run **`./update-kubernetes.sh`** or **`./update-minikube.sh`** from the release you are upgrading to. Pre-apply hooks in [`base-update/pre-apply.d/`](base-update/pre-apply.d/) drop the legacy Deployment and wait for pods to exit before `kubectl apply`. See **[`docs/update-reconhawx.md`](../docs/update-reconhawx.md)** and [`base-update/pre-apply.d/README.md`](base-update/pre-apply.d/README.md).
 
 **Manual:** plan a short database downtime window, then:
 

--- a/uninstall-kubernetes.sh
+++ b/uninstall-kubernetes.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Remove ReconHawx from a Kubernetes cluster (see docs/install-on-kubernetes.md).
+# Remove ReconHawx from a Kubernetes cluster (see docs/uninstall-reconhawx.md).
 # Deletes namespace reconhawx and cluster-scoped Kueue objects defined in kubernetes/base/kueue.
 # Optionally removes kueue-system, ingress-nginx, and metallb-system if you confirm (shared cluster).
 #


### PR DESCRIPTION
Restructure cluster and Minikube guides for operators (script-first, hostname notes, manual command blocks). Add uninstall doc; trim upgrade doc hooks detail into rules. Document GitHub Source archives as the default install source; update README, AGENTS, and kubernetes README links. Move script and migration runtime detail into k8s-cluster- lifecycle, migrations, and k8s-kustomize-patterns rules.

Made-with: Cursor