### PR TITLE
feat(typosquat): whitelist apex domains and auto-dismiss matching fin…

### DIFF
--- a/.cursor/rules/typosquat-detection.mdc
+++ b/.cursor/rules/typosquat-detection.mdc
@@ -544,6 +544,10 @@ Programs can configure **protected domains** - the legitimate domains they own. 
 
 Typosquat insertion **filtering** (`TyposquatFilteringService` check 2) uses the same `best_similarity_typo_to_protected` logic so gates stay consistent with stored scores.
 
+**Whitelisted apex domains (false-positive control):** Program JSONB `typosquat_filtering_settings.whitelisted_apex_domains` is a list of registrable apex strings (normalized on save via `TyposquatFilteringService.normalize_whitelisted_apex_domains`). When **typosquat filtering is enabled**, if the candidate FQDN’s registrable apex (same `_extract_apex_domain` as Check 0) matches any whitelist entry, insertion is rejected with reason `whitelisted_apex:<apex>`. All subdomains under that apex share the same registrable apex, so they are discarded too. This is independent of similarity to protected domains (legitimate third-party sites that look like typos). Check 0 (exact apex match to **protected** or **in-scope asset** apex) still applies first.
+
+**After whitelist updates:** When a program `PUT` adds new normalized apex entries (compared to the previous `whitelisted_apex_domains`), `TyposquatFindingsRepository.dismiss_typosquat_domains_for_whitelisted_apexes` dismisses existing non-terminal typosquat findings whose `typosquat_apex_domains.apex_domain` matches any added apex (case-insensitive). Each finding gets `status=dismissed`, an appended notes line, RF `comment` on the dismiss path, closure `closed_by_user_id` when the editor is a real user (not internal-service), and an action log when `closed_by_user_id` is set.
+
 **Similarity Output:**
 ```json
 {

--- a/src/api/app/repository/typosquat_findings_repo.py
+++ b/src/api/app/repository/typosquat_findings_repo.py
@@ -965,9 +965,11 @@ class TyposquatFindingsRepository(ProgramAccessMixin):
                 typosquat, assigned_to_username = result
                 _whois = TyposquatFindingsRepository._whois_public_fields_from_apex(typosquat)
 
+                apex_rel = getattr(typosquat, "typosquat_apex", None)
                 return {
                     'id': str(typosquat.id),
                     'typo_domain': typosquat.typo_domain,
+                    'typosquat_apex_domain': apex_rel.apex_domain if apex_rel else None,
                     'fuzzers': typosquat.fuzzer_types,
                     'info': {},  # info_data column removed
                     'timestamp': typosquat.detected_at.isoformat() if typosquat.detected_at else None,
@@ -1181,10 +1183,12 @@ class TyposquatFindingsRepository(ProgramAccessMixin):
                 for typosquat in typosquats:
                     logger.info(f"Typosquat: {typosquat}")
                     _w = TyposquatFindingsRepository._whois_public_fields_from_apex(typosquat)
+                    apex_rel = getattr(typosquat, "typosquat_apex", None)
                     result.append({
                         'id': str(typosquat.id),
                         'apex_domain_id': typosquat.apex_typosquat_domain_id,
                         'typo_domain': typosquat.typo_domain,
+                        'typosquat_apex_domain': apex_rel.apex_domain if apex_rel else None,
                         'fuzzers': typosquat.fuzzer_types,
                         'info': {},  # info_data column removed
                         'timestamp': typosquat.detected_at.isoformat() if typosquat.detected_at else None,
@@ -2380,6 +2384,10 @@ class TyposquatFindingsRepository(ProgramAccessMixin):
                 # Client must not overwrite append-only closure history
                 update_data.pop("closure_events", None)
                 update_data.pop("last_closure_at", None)
+                _CLOSURE_BY_MISSING = object()
+                closure_closed_by_override = update_data.pop(
+                    "_closure_closed_by_user_id", _CLOSURE_BY_MISSING
+                )
                 if whois_payload:
                     apex_name = extract_apex_domain(typosquat.typo_domain)
                     apex = TyposquatFindingsRepository.find_or_create_typosquat_apex_in_session(
@@ -2526,10 +2534,14 @@ class TyposquatFindingsRepository(ProgramAccessMixin):
                         existing_ev = typosquat.closure_events
                         if existing_ev is None or not isinstance(existing_ev, list):
                             existing_ev = []
+                        if closure_closed_by_override is not _CLOSURE_BY_MISSING:
+                            ev_closed_by = closure_closed_by_override
+                        else:
+                            ev_closed_by = typosquat.assigned_to or None
                         ev: Dict[str, Any] = {
                             "to_status": ns,
                             "closed_at": closed_at_str,
-                            "closed_by_user_id": typosquat.assigned_to or None,
+                            "closed_by_user_id": ev_closed_by,
                         }
                         typosquat.closure_events = list(existing_ev) + [ev]
                         typosquat.last_closure_at = closed_at_naive
@@ -2615,6 +2627,97 @@ class TyposquatFindingsRepository(ProgramAccessMixin):
                 db.rollback()
                 logger.error(f"Error updating typosquat domain {domain_id}: {str(e)}")
                 raise
+
+    @staticmethod
+    async def dismiss_typosquat_domains_for_whitelisted_apexes(
+        program_id: str,
+        apex_domains: List[str],
+        *,
+        closed_by_user_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Dismiss non-terminal typosquat findings whose typosquat apex matches one of
+        ``apex_domains`` (registrable apex strings, lowercase). Appends an explanatory
+        note and sets status to dismissed.
+        """
+        from uuid import UUID
+        from repository.action_log_repo import ActionLogRepository
+
+        apex_lower = {a.strip().lower() for a in (apex_domains or []) if a and str(a).strip()}
+        if not apex_lower:
+            return {"dismissed_count": 0, "finding_ids": []}
+
+        try:
+            prog_uuid = UUID(str(program_id))
+        except ValueError:
+            logger.warning(f"dismiss_typosquat_domains_for_whitelisted_apexes: invalid program_id {program_id}")
+            return {"dismissed_count": 0, "finding_ids": []}
+
+        targets: List[tuple] = []
+        async with get_db_session() as db:
+            rows = (
+                db.query(
+                    TyposquatDomain.id,
+                    TyposquatDomain.notes,
+                    TyposquatDomain.status,
+                    func.lower(TyposquatApexDomain.apex_domain).label("apex_l"),
+                )
+                .join(
+                    TyposquatApexDomain,
+                    TyposquatDomain.apex_typosquat_domain_id == TyposquatApexDomain.id,
+                )
+                .filter(
+                    TyposquatDomain.program_id == prog_uuid,
+                    func.lower(TyposquatApexDomain.apex_domain).in_(list(apex_lower)),
+                    TyposquatDomain.status.notin_(["dismissed", "resolved"]),
+                )
+                .all()
+            )
+            for row in rows:
+                targets.append((str(row[0]), row[1] or "", row[2] or "new", row[3]))
+
+        dismissed_ids: List[str] = []
+        comment_base = (
+            "Auto-dismissed: registrable apex added to typosquat whitelist"
+        )
+        for fid, old_notes, old_status, apex_l in targets:
+            comment = f"{comment_base} ({apex_l})."
+            note_line = f"[{comment}]"
+            merged_notes = (
+                (old_notes.rstrip() + "\n\n" + note_line).strip() if old_notes else note_line
+            )
+            ok = await TyposquatFindingsRepository.update_typosquat_domain(
+                fid,
+                {
+                    "status": "dismissed",
+                    "comment": comment,
+                    "notes": merged_notes,
+                    "_closure_closed_by_user_id": closed_by_user_id,
+                },
+            )
+            if ok:
+                dismissed_ids.append(fid)
+                if closed_by_user_id:
+                    try:
+                        await ActionLogRepository.log_action(
+                            entity_type="typosquat_finding",
+                            entity_id=fid,
+                            action_type="status_change",
+                            user_id=str(closed_by_user_id),
+                            old_value={"status": old_status},
+                            new_value={"status": "dismissed"},
+                            metadata={"comment": comment, "reason": "typosquat_apex_whitelist"},
+                        )
+                    except Exception as log_err:
+                        logger.warning(
+                            f"Action log failed for whitelist dismiss {fid}: {log_err}"
+                        )
+
+        logger.info(
+            f"Whitelist dismiss: program_id={program_id} apexes={sorted(apex_lower)} "
+            f"dismissed={len(dismissed_ids)}"
+        )
+        return {"dismissed_count": len(dismissed_ids), "finding_ids": dismissed_ids}
     
     @staticmethod
     async def _update_recordedfuture_alert_status(typosquat: TyposquatDomain, new_status: str, log_entry: Optional[str] = None, added_actions_taken: Optional[List[str]] = None, user_rf_uhash: Optional[str] = None) -> None:

--- a/src/api/app/routes/programs.py
+++ b/src/api/app/routes/programs.py
@@ -293,6 +293,20 @@ async def update_program(
         # Remove id field if present to avoid immutable field error
         update_data.pop('id', None)
 
+        from services.typosquat_filtering_service import TyposquatFilteringService
+
+        if "typosquat_filtering_settings" in update_data and isinstance(
+            update_data["typosquat_filtering_settings"], dict
+        ):
+            fs = dict(update_data["typosquat_filtering_settings"])
+            if "whitelisted_apex_domains" in fs:
+                fs["whitelisted_apex_domains"] = (
+                    TyposquatFilteringService.normalize_whitelisted_apex_domains(
+                        fs.get("whitelisted_apex_domains")
+                    )
+                )
+            update_data["typosquat_filtering_settings"] = fs
+
         # For PostgreSQL, we need to handle list fields differently
         # If overwrite is True, we replace the entire list
         # If overwrite is False, we merge the lists (add unique values)
@@ -324,10 +338,51 @@ async def update_program(
                             existing_list.append(dict(item))
                     update_data[field] = existing_list
         
+        from repository.typosquat_findings_repo import TyposquatFindingsRepository
+
+        old_fs = existing_program.get("typosquat_filtering_settings") or {}
+        old_wl_set = set(
+            TyposquatFilteringService.normalize_whitelisted_apex_domains(
+                old_fs.get("whitelisted_apex_domains")
+            )
+        )
+        added_whitelist_apexes: List[str] = []
+        if (
+            "typosquat_filtering_settings" in update_data
+            and isinstance(update_data["typosquat_filtering_settings"], dict)
+        ):
+            new_wl_set = set(
+                TyposquatFilteringService.normalize_whitelisted_apex_domains(
+                    update_data["typosquat_filtering_settings"].get("whitelisted_apex_domains")
+                )
+            )
+            added_whitelist_apexes = sorted(new_wl_set - old_wl_set)
+
         success = await ProgramRepository.update_program(existing_program["id"], update_data)
         
         if not success:
             raise HTTPException(status_code=500, detail="Failed to update program")
+
+        if added_whitelist_apexes:
+            closed_by: Optional[str] = None
+            uid = getattr(current_user, "id", None)
+            if uid is not None and not str(uid).startswith("internal-service-"):
+                closed_by = str(uid)
+            try:
+                dismiss_result = await TyposquatFindingsRepository.dismiss_typosquat_domains_for_whitelisted_apexes(
+                    existing_program["id"],
+                    added_whitelist_apexes,
+                    closed_by_user_id=closed_by,
+                )
+                logger.info(
+                    f"Typosquat whitelist auto-dismiss program={program_name}: "
+                    f"added_apexes={added_whitelist_apexes} "
+                    f"dismissed={dismiss_result.get('dismissed_count')}"
+                )
+            except Exception as dismiss_err:
+                logger.exception(
+                    f"Typosquat whitelist auto-dismiss failed for program={program_name}: {dismiss_err}"
+                )
         
         # Sync notification handlers when notification_settings changed
         if "notification_settings" in update_data:

--- a/src/api/app/services/typosquat_filtering_service.py
+++ b/src/api/app/services/typosquat_filtering_service.py
@@ -4,7 +4,7 @@ similarity to protected domains and protected keyword matching.
 """
 
 import logging
-from typing import Dict, List, Any, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from services.protected_domain_similarity_service import (
     _extract_apex_domain,
@@ -15,6 +15,30 @@ logger = logging.getLogger(__name__)
 
 
 class TyposquatFilteringService:
+
+    @staticmethod
+    def normalize_whitelisted_apex_domains(entries: Any) -> List[str]:
+        """
+        Normalize analyst-supplied whitelist entries to registrable apex strings
+        (lowercase, trimmed, deduplicated, order preserved).
+        """
+        if not entries:
+            return []
+        if not isinstance(entries, list):
+            return []
+        out: List[str] = []
+        seen: set = set()
+        for raw in entries:
+            if not isinstance(raw, str):
+                continue
+            s = raw.strip().lower()
+            if not s:
+                continue
+            apex = _extract_apex_domain(s).lower()
+            if apex and apex not in seen:
+                seen.add(apex)
+                out.append(apex)
+        return out
 
     @staticmethod
     def should_insert_domain(
@@ -38,14 +62,17 @@ class TyposquatFilteringService:
         min_similarity = filtering_settings.get("min_similarity_percent", 0.0)
         max_sim = 0.0  # Used in final return when similarity check ran
 
-        # --- Check 0: exact apex match with protected domain or asset apex → filter out ---
+        typo_apex_lower: Optional[str] = None
         if typo_domain:
-            typo_apex = _extract_apex_domain(typo_domain).lower()
+            typo_apex_lower = _extract_apex_domain(typo_domain).lower()
+
+        # --- Check 0: exact apex match with protected domain or asset apex → filter out ---
+        if typo_apex_lower:
             protected_apexes = {_extract_apex_domain(p).lower() for p in (protected_domains or [])}
             asset_apexes = {a.lower() for a in (asset_apex_domains or [])}
             blocked_apexes = protected_apexes | asset_apexes
-            if typo_apex in blocked_apexes:
-                if typo_apex in protected_apexes:
+            if typo_apex_lower in blocked_apexes:
+                if typo_apex_lower in protected_apexes:
                     logger.info(
                         f"Domain {typo_domain} filtered out: exact apex match with protected domain"
                     )
@@ -55,6 +82,18 @@ class TyposquatFilteringService:
                         f"Domain {typo_domain} filtered out: exact apex match with asset apex domain"
                     )
                     return False, "exact_apex_match:asset"
+
+        # --- Whitelist: legitimate third-party apexes → do not insert typosquat findings ---
+        whitelist_apexes = TyposquatFilteringService.normalize_whitelisted_apex_domains(
+            filtering_settings.get("whitelisted_apex_domains")
+        )
+        if typo_apex_lower and whitelist_apexes:
+            whitelist_set = set(whitelist_apexes)
+            if typo_apex_lower in whitelist_set:
+                logger.info(
+                    f"Domain {typo_domain} filtered out: apex on typosquat whitelist ({typo_apex_lower})"
+                )
+                return False, f"whitelisted_apex:{typo_apex_lower}"
 
         # --- Check 1: keyword matching (protected_subdomain_prefixes acts as keyword list) ---
         if protected_subdomain_prefixes and typo_domain:

--- a/src/api/tests/test_typosquat_filtering_service.py
+++ b/src/api/tests/test_typosquat_filtering_service.py
@@ -1,0 +1,91 @@
+"""Unit tests for typosquat insertion filtering (including whitelisted apex domains)."""
+
+import pytest
+
+from app.services.typosquat_filtering_service import TyposquatFilteringService
+
+
+def test_normalize_whitelisted_apex_domains_dedupes_and_extracts_apex():
+    assert TyposquatFilteringService.normalize_whitelisted_apex_domains(
+        ["Sub.Partner.COM", "partner.com", "", "  ", 123]
+    ) == ["partner.com"]
+
+
+def test_normalize_whitelisted_apex_domains_empty():
+    assert TyposquatFilteringService.normalize_whitelisted_apex_domains([]) == []
+    assert TyposquatFilteringService.normalize_whitelisted_apex_domains(None) == []
+
+
+def test_filtering_disabled_ignores_whitelist():
+    passes, reason = TyposquatFilteringService.should_insert_domain(
+        "app.partner.com",
+        protected_domains=["brand.com"],
+        protected_subdomain_prefixes=[],
+        filtering_settings={
+            "enabled": False,
+            "whitelisted_apex_domains": ["partner.com"],
+        },
+    )
+    assert passes is True
+    assert reason == "filtering_disabled"
+
+
+def test_whitelist_filters_subdomain_when_filtering_enabled():
+    passes, reason = TyposquatFilteringService.should_insert_domain(
+        "app.partner.com",
+        protected_domains=["brand.com"],
+        protected_subdomain_prefixes=[],
+        filtering_settings={
+            "enabled": True,
+            "min_similarity_percent": 60.0,
+            "whitelisted_apex_domains": ["partner.com"],
+        },
+    )
+    assert passes is False
+    assert reason == "whitelisted_apex:partner.com"
+
+
+def test_whitelist_accepts_paste_of_subdomain_entry():
+    """User may paste sub.partner.com; stored/compare as registrable apex."""
+    passes, reason = TyposquatFilteringService.should_insert_domain(
+        "foo.partner.com",
+        protected_domains=["brand.com"],
+        protected_subdomain_prefixes=[],
+        filtering_settings={
+            "enabled": True,
+            "min_similarity_percent": 60.0,
+            "whitelisted_apex_domains": ["sub.partner.com"],
+        },
+    )
+    assert passes is False
+    assert reason == "whitelisted_apex:partner.com"
+
+
+def test_whitelist_miss_continues_to_similarity():
+    passes, reason = TyposquatFilteringService.should_insert_domain(
+        "examp1e.com",
+        protected_domains=["example.com"],
+        protected_subdomain_prefixes=[],
+        filtering_settings={
+            "enabled": True,
+            "min_similarity_percent": 60.0,
+            "whitelisted_apex_domains": ["partner.com"],
+        },
+    )
+    assert passes is True
+    assert reason.startswith("similarity:")
+
+
+def test_empty_whitelist_no_effect():
+    passes, reason = TyposquatFilteringService.should_insert_domain(
+        "examp1e.com",
+        protected_domains=["example.com"],
+        protected_subdomain_prefixes=[],
+        filtering_settings={
+            "enabled": True,
+            "min_similarity_percent": 60.0,
+            "whitelisted_apex_domains": [],
+        },
+    )
+    assert passes is True
+    assert reason.startswith("similarity:")

--- a/src/frontend/src/pages/findings/TyposquatFindingDetail.js
+++ b/src/frontend/src/pages/findings/TyposquatFindingDetail.js
@@ -14,7 +14,7 @@ import {
   Collapse,
   Modal
 } from 'react-bootstrap';
-import api, { userManagementAPI } from '../../services/api';
+import api, { userManagementAPI, programAPI } from '../../services/api';
 import NotesSection from '../../components/NotesSection';
 import RelatedScreenshotsViewer from '../../components/RelatedScreenshotsViewer';
 import { formatDate, formatLocalDate } from '../../utils/dateUtils';
@@ -77,7 +77,7 @@ function TyposquatFindingDetail() {
   const { id } = useParams();
   const navigate = useNavigate();
   const location = useLocation();
-  const { user, isAdmin } = useAuth();
+  const { user, isAdmin, hasProgramPermission } = useAuth();
   
   // Initialize user cache with current user
   React.useEffect(() => {
@@ -117,6 +117,9 @@ function TyposquatFindingDetail() {
 
   const [recalculatingSimilarities, setRecalculatingSimilarities] = useState(false);
   const [similarityRecalcMessage, setSimilarityRecalcMessage] = useState({ text: '', type: '' });
+
+  const [whitelistApexLoading, setWhitelistApexLoading] = useState(false);
+  const [whitelistApexMessage, setWhitelistApexMessage] = useState({ text: '', type: '' });
 
   // AI analysis state
   const [aiAnalyzing, setAiAnalyzing] = useState(false);
@@ -351,6 +354,54 @@ function TyposquatFindingDetail() {
       });
     } finally {
       setRecalculatingSimilarities(false);
+    }
+  };
+
+  const handleWhitelistApexFromDetail = async () => {
+    if (!finding?.program_name) return;
+    const programName = finding.program_name;
+    if (!hasProgramPermission(programName, 'manager')) {
+      setWhitelistApexMessage({
+        text: 'Manager access is required to update the typosquat whitelist.',
+        type: 'warning'
+      });
+      return;
+    }
+    const apexRaw = (finding.typosquat_apex_domain || finding.typo_domain || '').trim().toLowerCase();
+    if (!apexRaw) {
+      setWhitelistApexMessage({ text: 'No apex available for this finding.', type: 'warning' });
+      return;
+    }
+    try {
+      setWhitelistApexLoading(true);
+      setWhitelistApexMessage({ text: '', type: '' });
+      setError(null);
+      const prog = await programAPI.getByName(programName);
+      const fs = { ...(prog.typosquat_filtering_settings || {}) };
+      const existing = Array.isArray(fs.whitelisted_apex_domains)
+        ? fs.whitelisted_apex_domains.map((e) => String(e))
+        : [];
+      const lower = new Set(existing.map((e) => e.trim().toLowerCase()).filter(Boolean));
+      if (!lower.has(apexRaw)) {
+        existing.push(apexRaw);
+      }
+      fs.whitelisted_apex_domains = existing;
+      await programAPI.update(programName, { typosquat_filtering_settings: fs }, true);
+      setWhitelistApexMessage({
+        text:
+          `Registrable apex was added to the typosquat whitelist for ${programName}. ` +
+          'Matching open findings were auto-dismissed with an explanatory note.',
+        type: 'success'
+      });
+      await refreshFindingAfterSimilarityRecalc();
+      setTimeout(() => setWhitelistApexMessage({ text: '', type: '' }), 10000);
+    } catch (err) {
+      setWhitelistApexMessage({
+        text: err.response?.data?.detail || err.message || 'Failed to update whitelist',
+        type: 'danger'
+      });
+    } finally {
+      setWhitelistApexLoading(false);
     }
   };
 
@@ -1233,6 +1284,26 @@ function TyposquatFindingDetail() {
                     </>
                   )}
                 </Button>
+          {finding.program_name && hasProgramPermission(finding.program_name, 'manager') && (
+            <Button
+              variant="outline-secondary"
+              onClick={handleWhitelistApexFromDetail}
+              disabled={whitelistApexLoading}
+              className="me-2"
+              title="Add this finding’s registrable apex to the program typosquat whitelist and auto-dismiss open findings on that apex"
+            >
+              {whitelistApexLoading ? (
+                <>
+                  <Spinner animation="border" size="sm" className="me-2" />
+                  Saving...
+                </>
+              ) : (
+                <>
+                  <i className="bi bi-patch-check"></i> Whitelist apex
+                </>
+              )}
+            </Button>
+          )}
           <Button 
             variant="outline-danger" 
             onClick={() => setShowDeleteModal(true)}
@@ -1245,6 +1316,12 @@ function TyposquatFindingDetail() {
           </Button>
         </div>
       </div>
+
+      {whitelistApexMessage.text && (
+        <Alert variant={whitelistApexMessage.type} className="mb-4">
+          {whitelistApexMessage.text}
+        </Alert>
+      )}
 
       {/* Basic Information */}
       <Card className="dashboard-panel mb-4">

--- a/src/frontend/src/pages/findings/TyposquatFindings.js
+++ b/src/frontend/src/pages/findings/TyposquatFindings.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { 
   Container, 
   Card, 
@@ -19,7 +19,7 @@ import {
 import { useNavigate, useSearchParams, useLocation, Link } from 'react-router-dom';
 import { useProgramFilter } from '../../contexts/ProgramFilterContext';
 import { useAuth } from '../../contexts/AuthContext';
-import api, { jobAPI, userManagementAPI } from '../../services/api';
+import api, { jobAPI, userManagementAPI, programAPI } from '../../services/api';
 import { formatDate } from '../../utils/dateUtils';
 import { initializeUserCache } from '../../utils/userUtils';
 import { usePageTitle, formatPageTitle } from '../../hooks/usePageTitle';
@@ -97,7 +97,7 @@ function TyposquatFindings() {
     return null; // No validation error
   };
   const { selectedProgram, programs } = useProgramFilter();
-  const { user, isAdmin } = useAuth();
+  const { user, isAdmin, hasProgramPermission } = useAuth();
   
   // Initialize user cache with current user
   React.useEffect(() => {
@@ -226,6 +226,9 @@ function TyposquatFindings() {
   const [aiDefaultModel, setAiDefaultModel] = useState('');
   const [aiModelsLoading, setAiModelsLoading] = useState(false);
   const [aiAnalysisBatchMessage, setAiAnalysisBatchMessage] = useState({ text: '', type: '' });
+
+  const [whitelistApexLoading, setWhitelistApexLoading] = useState(false);
+  const [whitelistApexMessage, setWhitelistApexMessage] = useState({ text: '', type: '' });
   
   // Fallback programs state if context doesn't have them
   const [localPrograms, setLocalPrograms] = useState([]);
@@ -1311,6 +1314,80 @@ function TyposquatFindings() {
     }
   }, []);
 
+  const whitelistApexFromSelection = useMemo(() => {
+    if (selectedItems.size === 0) {
+      return { showButton: false, programName: null };
+    }
+    const selected = findings.filter((f) => selectedItems.has(f.id));
+    const programNames = [...new Set(selected.map((f) => f.program_name).filter(Boolean))];
+    if (programNames.length !== 1) {
+      return { showButton: false, programName: null };
+    }
+    const programName = programNames[0];
+    if (!hasProgramPermission(programName, 'manager')) {
+      return { showButton: false, programName: null };
+    }
+    return { showButton: true, programName };
+  }, [findings, selectedItems, hasProgramPermission]);
+
+  const handleWhitelistSelectedApexes = useCallback(async () => {
+    const selected = findings.filter((f) => selectedItems.has(f.id));
+    if (selected.length === 0) return;
+    const programNames = [...new Set(selected.map((f) => f.program_name).filter(Boolean))];
+    if (programNames.length !== 1) {
+      setWhitelistApexMessage({ text: 'Select findings from a single program.', type: 'warning' });
+      return;
+    }
+    const programName = programNames[0];
+    if (!hasProgramPermission(programName, 'manager')) {
+      setWhitelistApexMessage({
+        text: 'Manager access is required to update the typosquat whitelist.',
+        type: 'warning',
+      });
+      return;
+    }
+    const apexSet = new Set();
+    for (const f of selected) {
+      const raw = (f.typosquat_apex_domain || f.typo_domain || '').trim().toLowerCase();
+      if (raw) apexSet.add(raw);
+    }
+    if (apexSet.size === 0) {
+      setWhitelistApexMessage({ text: 'No apex could be derived from the selection.', type: 'warning' });
+      return;
+    }
+    try {
+      setWhitelistApexLoading(true);
+      setWhitelistApexMessage({ text: '', type: '' });
+      setError('');
+      const prog = await programAPI.getByName(programName);
+      const fs = { ...(prog.typosquat_filtering_settings || {}) };
+      const existing = Array.isArray(fs.whitelisted_apex_domains)
+        ? fs.whitelisted_apex_domains.map((e) => String(e))
+        : [];
+      const lower = new Set(existing.map((e) => e.trim().toLowerCase()).filter(Boolean));
+      for (const a of apexSet) {
+        if (!lower.has(a)) {
+          existing.push(a);
+          lower.add(a);
+        }
+      }
+      fs.whitelisted_apex_domains = existing;
+      await programAPI.update(programName, { typosquat_filtering_settings: fs }, true);
+      setWhitelistApexMessage({
+        text: `Added ${apexSet.size} apex domain(s) to the typosquat whitelist for ${programName}. Open findings on those apexes were auto-dismissed with a note; new findings are discarded when typosquat filtering is enabled.`,
+        type: 'success',
+      });
+      setSelectedItems(new Set());
+    } catch (err) {
+      setWhitelistApexMessage({
+        text: err.response?.data?.detail || err.message || 'Failed to update whitelist',
+        type: 'danger',
+      });
+    } finally {
+      setWhitelistApexLoading(false);
+    }
+  }, [findings, selectedItems, hasProgramPermission]);
+
   const handleOpenAiAnalysisBatchModal = () => {
     if (!isAdmin() || selectedItems.size === 0) return;
     setBatchAiForce(false);
@@ -1663,6 +1740,27 @@ function TyposquatFindings() {
               )}
             </Button>
           )}
+          {whitelistApexFromSelection.showButton && (
+            <Button
+              variant="outline-secondary"
+              size="sm"
+              onClick={handleWhitelistSelectedApexes}
+              disabled={whitelistApexLoading}
+              className="me-2"
+              title="Append registrable apex of selected findings to the program typosquat whitelist (manager only)"
+            >
+              {whitelistApexLoading ? (
+                <>
+                  <Spinner animation="border" size="sm" className="me-2" />
+                  Saving...
+                </>
+              ) : (
+                <>
+                  <i className="bi bi-patch-check"></i> Whitelist apex ({selectedItems.size})
+                </>
+              )}
+            </Button>
+          )}
           <Button
             variant="outline-success"
             size="sm"
@@ -1704,6 +1802,12 @@ function TyposquatFindings() {
       {typosquatBatchMessage.text && (
         <Alert variant={typosquatBatchMessage.type} className="mb-4">
           {typosquatBatchMessage.text}
+        </Alert>
+      )}
+
+      {whitelistApexMessage.text && (
+        <Alert variant={whitelistApexMessage.type} className="mb-4">
+          {whitelistApexMessage.text}
         </Alert>
       )}
 

--- a/src/frontend/src/pages/programs/ProgramDetail.js
+++ b/src/frontend/src/pages/programs/ProgramDetail.js
@@ -104,7 +104,8 @@ function ProgramDetail() {
   const [savingCtMonitorProgram, setSavingCtMonitorProgram] = useState(false);
   const [typosquatFiltering, setTyposquatFiltering] = useState({
     enabled: false,
-    min_similarity_percent: ''
+    min_similarity_percent: '',
+    whitelisted_apex_domains_text: ''
   });
   // AI prompt settings
   const [aiPrompts, setAiPrompts] = useState({ typosquat: '' });
@@ -233,9 +234,12 @@ function ProgramDetail() {
       min_similarity_percent: settings.min_similarity_percent ?? ''
     });
     const filterSettings = program?.typosquat_filtering_settings || {};
+    const wl = filterSettings.whitelisted_apex_domains;
+    const wlText = Array.isArray(wl) && wl.length ? wl.join('\n') : '';
     setTyposquatFiltering({
       enabled: filterSettings.enabled ?? false,
-      min_similarity_percent: filterSettings.min_similarity_percent ?? ''
+      min_similarity_percent: filterSettings.min_similarity_percent ?? '',
+      whitelisted_apex_domains_text: wlText
     });
     const prompts = (program?.ai_analysis_settings?.prompts) || {};
     setAiPrompts({ typosquat: prompts.typosquat || '' });
@@ -319,7 +323,14 @@ function ProgramDetail() {
       setSavingFiltering(true);
       setError('');
       const minSim = typosquatFiltering.min_similarity_percent === '' ? null : Number(typosquatFiltering.min_similarity_percent);
-      const payload = { enabled: typosquatFiltering.enabled };
+      const whitelistLines = (typosquatFiltering.whitelisted_apex_domains_text || '')
+        .split('\n')
+        .map((line) => line.trim())
+        .filter(Boolean);
+      const payload = {
+        enabled: typosquatFiltering.enabled,
+        whitelisted_apex_domains: whitelistLines
+      };
       if (minSim != null) payload.min_similarity_percent = minSim;
       await programAPI.update(programName, { typosquat_filtering_settings: payload }, true);
       setSuccess('Typosquat filtering settings updated');
@@ -1736,6 +1747,7 @@ function ProgramDetail() {
             <Card.Body>
               <p className="text-muted mb-3">
                 When enabled, new typosquat domains must meet the minimum similarity threshold with a protected domain OR contain a protected keyword to be inserted.
+                Domains under a whitelisted apex are always discarded.
                 Domains that don&apos;t pass are discarded (RecordedFuture alerts are auto-resolved).
               </p>
               <Row>
@@ -1770,6 +1782,26 @@ function ProgramDetail() {
                   </Form.Group>
                 </Col>
               </Row>
+              <Form.Group className="mb-0">
+                <Form.Label>Whitelisted apex domains</Form.Label>
+                <Form.Control
+                  as="textarea"
+                  rows={4}
+                  placeholder={'One registrable apex per line, e.g.\npartner.com\naffiliate-brand.org'}
+                  value={typosquatFiltering.whitelisted_apex_domains_text}
+                  onChange={(e) =>
+                    setTyposquatFiltering({
+                      ...typosquatFiltering,
+                      whitelisted_apex_domains_text: e.target.value
+                    })
+                  }
+                  disabled={!isUserManager}
+                />
+                <Form.Text className="text-muted">
+                  When filtering is enabled, new typosquat candidates whose registrable apex matches a line here are discarded (including all subdomains under that apex).
+                  When you save newly added apex lines, existing open findings on those apexes are auto-dismissed with an explanatory note.
+                </Form.Text>
+              </Form.Group>
             </Card.Body>
           </Card>
 


### PR DESCRIPTION
…dings

When typosquat filtering is enabled, candidates under listed registrable apexes are rejected at insert. Saving newly added whitelist lines dismisses existing open findings on those apexes with an explanatory note and optional action log. Managers can edit the list on the program page or whitelist from the typosquat list or finding detail.

Made-with: Cursor