### PR TITLE
docs(user): recon tasks reference for workflows

### DIFF
--- a/docs/user/recon-tasks.md
+++ b/docs/user/recon-tasks.md
@@ -1,0 +1,73 @@
+# Recon tasks reference (workflows)
+
+This guide describes **workflow recon tasks** implemented in the runner: what each task is for, which **input kinds** it expects, and which **outputs** it can produce for the rest of a workflow or for the platform.
+
+For how to wire inputs and run workflows in the UI, see [Workflows](workflows.md).
+
+## How to read this page
+
+### Input type (technical)
+
+Each task declares one or more **runner input types**. In the UI you usually connect **workflow inputs** or **program assets**; those map to the same underlying kinds:
+
+| Input type | Meaning for you |
+|------------|-----------------|
+| **string** | Plain text lines the worker treats as targets (often hostnames, IPs, URLs, or CIDRs depending on the task). Multi-value workflow inputs become multiple lines. |
+| **subdomain** | Subdomain records (hostnames), including from **Program assets → Subdomains**. |
+| **ip** | IP addresses. |
+| **url** | Full URLs (`http://` or `https://`). |
+
+Some tasks accept **more than one** input kind (for example Nuclei).
+
+### Output type
+
+**Assets** (subdomains, IPs, services, URLs, certificates, screenshots, apex domains) are stored on the program and can feed **downstream tasks** in the same workflow.
+
+**Findings** (Nuclei, WPScan, broken links, typosquat-related types) are stored as **findings** rather than generic assets. They appear in the findings areas of the product; not every downstream task can consume them as workflow input—check the task you want to chain.
+
+A few tasks **write results only through the API** during the run (for example typosquat detection). They still complete successfully but may declare **no asset output types** because results are not emitted as standard workflow assets.
+
+### Parameters and limits
+
+Timeouts, chunk sizes, wordlists, and similar knobs are controlled by **recon task parameters** (built-in defaults, optionally overridden by administrators). This document does not list every parameter; use task **Configure → Parameters** in the UI and admin documentation for operational tuning.
+
+---
+
+## Task catalog
+
+| Task | What it does | Input type | Output type |
+|------|----------------|------------|---------------|
+| **resolve_domain** | DNS forward lookup: resolves hostnames to IPv4/IPv6 addresses (dnsx). | string (hostnames) | subdomain, ip |
+| **resolve_ip** | Reverse DNS: maps IP addresses to names (dnsx). | string (IPs) | subdomain, ip |
+| **resolve_ip_cidr** | Expands a CIDR block into individual IPs, resolves PTR-style names where applicable, and can orchestrate follow-on jobs (including optional port scans). | string (CIDR such as `10.0.0.0/24`, or single IPs) | subdomain, ip, service |
+| **subdomain_finder** | Passive subdomain discovery (subfinder) from seed domains. | string (apex or seed domains) | subdomain |
+| **dns_bruteforce** | Active subdomain brute force using DNS and a wordlist (PureDNS-style pipeline). | string (parent domains / zones to brute force) | subdomain, ip |
+| **subdomain_permutations** | Generates likely subdomain permutations (gotator) and resolves them. | string (base domains) | subdomain, ip |
+| **port_scan** | TCP/UDP port scan: accepts bare IPs or `ip:port` targets for focused checks. | string | service |
+| **nuclei_scan** | Runs the Nuclei template engine against targets; records template matches as findings and can also surface related hosts, URLs, and services from results. | subdomain, ip, or url | nuclei finding, subdomain, ip, service, url |
+| **wpscan** | WordPress security scan (WPScan) for core, plugins, and themes. | url | wpscan finding |
+| **test_http** | Probes HTTP/HTTPS with httpx: separates full URLs from bare hostnames, fingerprints TLS, detects technologies, and collects live services, hosts, IPs, URLs, and certificate material from responses. | string (URLs and/or hostnames) | service, subdomain, ip, url, certificate |
+| **whois_domain_check** | WHOIS lookup for registrable domains; attaches structured WHOIS to apex domain records. | string (domain names) | apex_domain |
+| **crawl_website** | Web crawl from seed URLs to discover more URLs on the same sites. | string (seed URLs) | url |
+| **screenshot_website** | Captures rendered page screenshots for URLs. | string (URLs) | screenshot |
+| **fuzz_website** | Directory/file discovery with ffuf using a wordlist. | string (base URLs to fuzz) | url |
+| **detect_broken_links** | Checks pages for broken or risky outbound links (including social links and hijackable unregistered domains). | string (page URLs, `http://` or `https://`) | broken_link finding |
+| **typosquat_detection** | Generates and analyzes typosquat candidates (dnstwist and related checks), risk scoring, optional screenshots; persists typosquat findings via the API. | subdomain | _(findings written during the run; no standard asset output list)_ |
+| **shell_command** | Runs a configured shell pipeline; optional stdin from workflow input. Parameters define the command; mapped input is fed on standard input when provided. | string (stdin text) | string (raw stdout/stderr capture) |
+| **asset_batch_generator** | **Testing only:** generates synthetic subdomains, IPs, services, URLs, certificates, and sample Nuclei-style findings for load tests. | string (program name seed) | subdomain, ip, service, url, certificate, nuclei finding, string (synthetic apex payloads) |
+
+---
+
+## Choosing the right task
+
+- **Discovery:** `subdomain_finder` (passive) vs `dns_bruteforce` / `subdomain_permutations` (active / combinatorial)—start passive when you want less noise.
+- **Resolution:** `resolve_domain` for names → IPs, `resolve_ip` for IPs → names; use `resolve_ip_cidr` only when the scope is an IP block you intentionally control.
+- **Exposure:** `port_scan` then `nuclei_scan` or `wpscan` (for WordPress) is a common sequence; map the same assets or URLs forward.
+- **Web surface:** `crawl_website` and `fuzz_website` expand URL lists; `screenshot_website` and `test_http` add evidence for review.
+
+---
+
+## Related documentation
+
+- [Workflows](workflows.md) — builder, input sources, and mapping
+- [Programs](programs.md) — where discovered assets and scope live

--- a/docs/user/recon-tasks.md
+++ b/docs/user/recon-tasks.md
@@ -53,8 +53,6 @@ Timeouts, chunk sizes, wordlists, and similar knobs are controlled by **recon ta
 | **fuzz_website** | Directory/file discovery with ffuf using a wordlist. | string (base URLs to fuzz) | url |
 | **detect_broken_links** | Checks pages for broken or risky outbound links (including social links and hijackable unregistered domains). | string (page URLs, `http://` or `https://`) | broken_link finding |
 | **typosquat_detection** | Generates and analyzes typosquat candidates (dnstwist and related checks), risk scoring, optional screenshots; persists typosquat findings via the API. | subdomain | _(findings written during the run; no standard asset output list)_ |
-| **shell_command** | Runs a configured shell pipeline; optional stdin from workflow input. Parameters define the command; mapped input is fed on standard input when provided. | string (stdin text) | string (raw stdout/stderr capture) |
-| **asset_batch_generator** | **Testing only:** generates synthetic subdomains, IPs, services, URLs, certificates, and sample Nuclei-style findings for load tests. | string (program name seed) | subdomain, ip, service, url, certificate, nuclei finding, string (synthetic apex payloads) |
 
 ---
 

--- a/docs/user/workflows.md
+++ b/docs/user/workflows.md
@@ -8,7 +8,7 @@ It covers:
 - Common task input types you will configure
 - Validation and troubleshooting basics
 
-It intentionally does **not** go deep into individual runner task internals; that belongs in a separate task-focused guide.
+For a concise catalog of each recon task (purpose, input kind, outputs), see [Recon tasks reference](recon-tasks.md).
 
 ## Before you start
 
@@ -243,5 +243,6 @@ Avoid early complexity:
 
 - [Getting Started](getting-started.md)
 - [Programs Guide](programs.md)
+- [Recon tasks reference](recon-tasks.md)
 - [Installation on Kubernetes](../install-on-kubernetes.md)
 - [Installation on Minikube](../install-on-minikube.md)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds user-facing documentation that lists each workflow recon task with a short description, expected input kinds, and produced outputs (assets vs findings). Links the new page from the workflows guide so readers can jump from general workflow usage to task-level detail.

## Changes

- New `docs/user/recon-tasks.md` — recon task catalog and how to interpret runner input/output types in the UI. The catalog covers standard recon tasks only (excludes `shell_command` and `asset_batch_generator`).
- `docs/user/workflows.md` — cross-links to the recon tasks reference.

## Notes

- Input/output columns align with runner `Task` definitions in `src/runner/app/tasks/`.
- `typosquat_detection` persists findings via the API during execution; the doc explains why it has no standard asset output list.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a93716ae-1693-4fae-a9d6-378dd2b9e6d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a93716ae-1693-4fae-a9d6-378dd2b9e6d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

