### PR TITLE
feat(programs): allow renaming an existing program

### DIFF
--- a/src/api/app/routes/programs.py
+++ b/src/api/app/routes/programs.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, HTTPException, Path, Body, Query, Depends, status
 from typing import Dict, Any, Optional, Literal, List
 from pydantic import BaseModel, Field
+from sqlalchemy.exc import IntegrityError
 import logging
 from models.program import APIProgram
 from repository import ProgramRepository, EventHandlerConfigRepository
@@ -304,6 +305,40 @@ async def update_program(
         # Remove id field if present to avoid immutable field error
         update_data.pop('id', None)
 
+        renamed_to: Optional[str] = None
+        if "name" in update_data:
+            raw_name = update_data["name"]
+            if raw_name is None:
+                update_data.pop("name", None)
+            elif not isinstance(raw_name, str):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Program name must be a string",
+                )
+            else:
+                new_name = raw_name.strip()
+                if not new_name:
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail="Program name cannot be empty",
+                    )
+                if len(new_name) > 255:
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail="Program name must be at most 255 characters",
+                    )
+                if new_name == existing_program["name"]:
+                    update_data.pop("name", None)
+                else:
+                    name_taken = await ProgramRepository.get_program_by_name(new_name)
+                    if name_taken and name_taken.get("id") != existing_program.get("id"):
+                        raise HTTPException(
+                            status_code=status.HTTP_409_CONFLICT,
+                            detail=f"A program named '{new_name}' already exists",
+                        )
+                    update_data["name"] = new_name
+                    renamed_to = new_name
+
         from services.typosquat_filtering_service import TyposquatFilteringService
 
         if "typosquat_filtering_settings" in update_data and isinstance(
@@ -403,10 +438,23 @@ async def update_program(
             )
             added_whitelist_apexes = sorted(new_wl_set - old_wl_set)
 
-        success = await ProgramRepository.update_program(existing_program["id"], update_data)
-        
+        try:
+            success = await ProgramRepository.update_program(existing_program["id"], update_data)
+        except IntegrityError as ie:
+            logger.warning(
+                "Program update integrity error program_id=%s: %s",
+                existing_program.get("id"),
+                ie,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="A program with this name already exists",
+            )
+
         if not success:
             raise HTTPException(status_code=500, detail="Failed to update program")
+
+        final_program_name = renamed_to if renamed_to else program_name
 
         if added_whitelist_apexes:
             closed_by: Optional[str] = None
@@ -420,13 +468,13 @@ async def update_program(
                     closed_by_user_id=closed_by,
                 )
                 logger.info(
-                    f"Typosquat whitelist auto-dismiss program={program_name}: "
+                    f"Typosquat whitelist auto-dismiss program={final_program_name}: "
                     f"added_apexes={added_whitelist_apexes} "
                     f"dismissed={dismiss_result.get('dismissed_count')}"
                 )
             except Exception as dismiss_err:
                 logger.exception(
-                    f"Typosquat whitelist auto-dismiss failed for program={program_name}: {dismiss_err}"
+                    f"Typosquat whitelist auto-dismiss failed for program={final_program_name}: {dismiss_err}"
                 )
         
         # Sync notification handlers when notification_settings changed
@@ -439,7 +487,7 @@ async def update_program(
                     update_data["notification_settings"],
                 )
             except Exception as e:
-                logger.warning(f"Failed to sync notification handlers for {program_name}: {e}")
+                logger.warning(f"Failed to sync notification handlers for {final_program_name}: {e}")
 
         ct_related = {
             "ct_monitoring_enabled",
@@ -453,11 +501,13 @@ async def update_program(
         ):
             await sync_ct_monitor_program_config()
         
-        logger.info(f"Successfully updated program: {program_name}")
+        logger.info(f"Successfully updated program: {final_program_name}")
         response: Dict[str, Any] = {
             "status": "success",
-            "message": f"Program {program_name} updated successfully",
+            "message": f"Program {final_program_name} updated successfully",
         }
+        if renamed_to:
+            response["data"] = {"name": renamed_to}
         if scope_warnings:
             response["scope_warnings"] = scope_warnings
         return response

--- a/src/api/tests/test_program_rename.py
+++ b/src/api/tests/test_program_rename.py
@@ -1,0 +1,150 @@
+"""Tests for renaming a program via PUT /programs/{program_name}."""
+
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from app.models.user_postgres import UserResponse
+
+_MINIMAL_PROGRAM = {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "name": "oldname",
+    "scope_domains": [],
+    "out_of_scope_domains": [],
+    "typosquat_filtering_settings": None,
+    "ct_monitoring_enabled": False,
+}
+
+
+class TestProgramRename:
+    @patch(
+        "app.routes.programs.ProgramRepository.update_program",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "app.routes.programs.ProgramRepository.get_program_by_name",
+        new_callable=AsyncMock,
+    )
+    @pytest.mark.asyncio
+    async def test_put_rename_success(
+        self,
+        mock_get_program,
+        mock_update_program,
+        client: httpx.AsyncClient,
+        mock_user_superuser: UserResponse,
+    ):
+        """Superuser can rename; response includes data.name."""
+
+        async def _get_by_name(name: str):
+            if name == "oldname":
+                return dict(_MINIMAL_PROGRAM)
+            if name == "newname":
+                return None
+            return None
+
+        mock_get_program.side_effect = _get_by_name
+        mock_update_program.return_value = True
+
+        response = await client.put(
+            "/programs/oldname",
+            json={"name": "newname"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "success"
+        assert data.get("data") == {"name": "newname"}
+        assert "newname" in data["message"]
+
+        mock_update_program.assert_awaited_once()
+        _pid, payload = mock_update_program.await_args.args
+        assert payload["name"] == "newname"
+
+    @patch(
+        "app.routes.programs.ProgramRepository.get_program_by_name",
+        new_callable=AsyncMock,
+    )
+    @pytest.mark.asyncio
+    async def test_put_rename_conflict_duplicate_name(
+        self,
+        mock_get_program,
+        client: httpx.AsyncClient,
+        mock_user_superuser: UserResponse,
+    ):
+        """409 when target name is already used by another program."""
+
+        async def _get_by_name(name: str):
+            if name == "oldname":
+                return dict(_MINIMAL_PROGRAM)
+            if name == "taken":
+                return {
+                    "id": "00000000-0000-0000-0000-000000000099",
+                    "name": "taken",
+                }
+            return None
+
+        mock_get_program.side_effect = _get_by_name
+
+        response = await client.put(
+            "/programs/oldname",
+            json={"name": "taken"},
+        )
+
+        assert response.status_code == 409
+        assert "already exists" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_put_rename_forbidden_non_manager(
+        self,
+        client: httpx.AsyncClient,
+        mock_user_restricted: UserResponse,
+    ):
+        """403 when user lacks manager access to the program."""
+
+        response = await client.put(
+            "/programs/program-a",
+            json={"name": "new-name"},
+        )
+
+        assert response.status_code == 403
+        assert "Manager" in response.json()["detail"]
+
+    @patch(
+        "app.routes.programs.ProgramRepository.update_program",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "app.routes.programs.ProgramRepository.get_program_by_name",
+        new_callable=AsyncMock,
+    )
+    @pytest.mark.asyncio
+    async def test_put_rename_integrity_error_returns_409(
+        self,
+        mock_get_program,
+        mock_update_program,
+        client: httpx.AsyncClient,
+        mock_user_superuser: UserResponse,
+    ):
+        """Race on unique constraint maps to 409."""
+
+        async def _get_by_name(name: str):
+            if name == "oldname":
+                return dict(_MINIMAL_PROGRAM)
+            if name == "newname":
+                return None
+            return None
+
+        mock_get_program.side_effect = _get_by_name
+        mock_update_program.side_effect = IntegrityError(
+            "stmt", None, Exception("duplicate key")
+        )
+
+        response = await client.put(
+            "/programs/oldname",
+            json={"name": "newname"},
+        )
+
+        assert response.status_code == 409
+        assert "already exists" in response.json()["detail"].lower()

--- a/src/frontend/src/pages/programs/ProgramDetail.js
+++ b/src/frontend/src/pages/programs/ProgramDetail.js
@@ -16,10 +16,11 @@ import {
   Tabs,
   Tab
 } from 'react-bootstrap';
-import { programAPI, aiAPI } from '../../services/api';
+import { programAPI, aiAPI, authAPI } from '../../services/api';
 import EventHandlerForm from '../../components/EventHandlerForm';
 import ScopeDomainsEditor from '../../components/programs/ScopeDomainsEditor';
 import { useAuth } from '../../contexts/AuthContext';
+import { useProgramFilter } from '../../contexts/ProgramFilterContext';
 import { formatDate } from '../../utils/dateUtils';
 import { usePageTitle, formatPageTitle } from '../../hooks/usePageTitle';
 
@@ -83,12 +84,15 @@ function mergeProgramNotificationSettings(programSettings) {
 function ProgramDetail() {
   const { programName } = useParams();
   const navigate = useNavigate();
-  const { hasProgramPermission } = useAuth();
+  const { hasProgramPermission, updateUser } = useAuth();
+  const { selectedProgram, setSelectedProgram, refreshPrograms } = useProgramFilter();
 
   const [program, setProgram] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [success, setSuccess] = useState('');
+  const [programNameDraft, setProgramNameDraft] = useState('');
+  const [savingProgramName, setSavingProgramName] = useState(false);
   const [savingNotifications, setSavingNotifications] = useState(false);
   const [savingAutoResolve, setSavingAutoResolve] = useState(false);
   const [typosquatAutoResolve, setTyposquatAutoResolve] = useState({
@@ -268,6 +272,9 @@ function ProgramDetail() {
           ? String(cms.similarity_threshold)
           : ''
     });
+    if (program?.name != null) {
+      setProgramNameDraft(program.name);
+    }
   }, [program]);
 
   useEffect(() => {
@@ -309,6 +316,39 @@ function ProgramDetail() {
   useEffect(() => {
     if (program && programName) loadEventHandlerConfig();
   }, [program, programName, loadEventHandlerConfig]);
+
+  const handleRenameProgram = async () => {
+    const trimmed = programNameDraft.trim();
+    if (!trimmed || !program || trimmed === program.name) return;
+    try {
+      setSavingProgramName(true);
+      setError('');
+      await programAPI.update(programName, { name: trimmed }, true);
+      const fresh = await authAPI.getCurrentUser();
+      updateUser(fresh);
+      if (selectedProgram === programName) {
+        setSelectedProgram(trimmed);
+      }
+      try {
+        await refreshPrograms();
+      } catch (e) {
+        console.warn('refreshPrograms after rename:', e);
+      }
+      setSuccess('Program name updated.');
+      navigate(`/programs/${encodeURIComponent(trimmed)}`, { replace: true });
+    } catch (err) {
+      const d = err.response?.data?.detail;
+      const msg =
+        typeof d === 'string'
+          ? d
+          : Array.isArray(d)
+            ? d.map((x) => (typeof x === 'string' ? x : x?.msg || '')).filter(Boolean).join(' ')
+            : err.message;
+      setError(msg || 'Failed to rename program');
+    } finally {
+      setSavingProgramName(false);
+    }
+  };
 
   useEffect(() => {
     // Sync local draft with program data when it loads/changes
@@ -1053,7 +1093,33 @@ function ProgramDetail() {
                 <tbody>
                   <tr>
                     <td width="200"><strong>Program Name:</strong></td>
-                    <td>{program.name}</td>
+                    <td>
+                      {isUserManager ? (
+                        <InputGroup className="flex-nowrap" style={{ maxWidth: 'min(100%, 32rem)' }}>
+                          <Form.Control
+                            type="text"
+                            value={programNameDraft}
+                            onChange={(e) => setProgramNameDraft(e.target.value)}
+                            disabled={savingProgramName}
+                            maxLength={255}
+                            aria-label="Program name"
+                          />
+                          <Button
+                            variant="primary"
+                            disabled={
+                              savingProgramName ||
+                              !programNameDraft.trim() ||
+                              programNameDraft.trim() === program.name
+                            }
+                            onClick={handleRenameProgram}
+                          >
+                            {savingProgramName ? 'Saving…' : 'Save'}
+                          </Button>
+                        </InputGroup>
+                      ) : (
+                        program.name
+                      )}
+                    </td>
                   </tr>
                   <tr>
                     <td><strong>Created:</strong></td>


### PR DESCRIPTION
Validate new names (length, uniqueness) and return 409 on conflicts or integrity errors. Managers edit the name on the program overview, refresh session and program list state, and navigate to the new URL. Add API tests for success, forbidden, duplicate, and race cases.

Made-with: Cursor