### PR TITLE
fix(workflows): allow long program names in Kubernetes workflow and w…

### DIFF
--- a/.cursor/rules/api-workflow-k8s.mdc
+++ b/.cursor/rules/api-workflow-k8s.mdc
@@ -134,7 +134,15 @@ except ApiException as e:
 
 ### Job with Kueue Annotations
 
+Program names are not copied into **labels** (Kubernetes label values max 63 characters). Use label `program-id` (Postgres program UUID) and annotation `reconhawx.io/program-name` for the full name. `create_runner_job` resolves `program_id` from the DB when only `program_name` is present. Queue listing filters workloads with `program-id=<uuid>` after resolving the program row.
+
 ```python
+prog_labels, prog_ann = self._workflow_program_metadata_fragments(workflow_data)
+job_annotations = {
+    "kueue.x-k8s.io/queue-name": self.kueue_workflow_queue,
+    "kueue.x-k8s.io/priority-class": self.kueue_priority_class,
+    **prog_ann,
+}
 job = {
     "apiVersion": "batch/v1",
     "kind": "Job",
@@ -145,13 +153,10 @@ job = {
             "app": "workflow-runner",
             "execution-id": execution_id,
             "workflow-id": execution_id,
-            "program": workflow_data.get('program_name', ''),
-            "priority": priority
+            "priority": priority,
+            **prog_labels,
         },
-        "annotations": {
-            "kueue.x-k8s.io/queue-name": self.kueue_workflow_queue,
-            "kueue.x-k8s.io/priority-class": self.kueue_priority_class
-        }
+        "annotations": job_annotations,
     },
     "spec": {
         "parallelism": 1,

--- a/.cursor/rules/runner-job-management.mdc
+++ b/.cursor/rules/runner-job-management.mdc
@@ -315,6 +315,12 @@ async def _process_message(self, msg):
 def generate_job_crd(self, job_params: Dict) -> client.V1Job:
     """Generate Kubernetes Job manifest"""
     
+    # Program: label `program-id` (UUID) + annotation `reconhawx.io/program-name` — never
+    # `program-name` as a label (Kubernetes max 63 chars per label value). See
+    # `KubernetesService._worker_program_k8s_fragments` in `src/runner/app/services/kubernetes.py`.
+    # `workflow-name`, `task-name`, `step-name` labels use `_sanitize_k8s_label_value` (allowed
+    # charset + 63-char cap) because `WORKFLOW_NAME` and step titles can contain spaces.
+    prog_labels, prog_ann = self._worker_program_k8s_fragments(job_params)
     metadata = client.V1ObjectMeta(
         name=f"worker-{job_params['job_id']}",
         labels={
@@ -322,10 +328,11 @@ def generate_job_crd(self, job_params: Dict) -> client.V1Job:
             "app": "worker",
             "task-id": job_params["job_id"],
             "workflow-id": job_params["workflow_id"],
-            "program-name": job_params["program_name"],
             "task-name": job_params["task_name"],
-            "step-name": job_params["step_name"]
-        }
+            "step-name": job_params["step_name"],
+            **prog_labels,
+        },
+        annotations=dict(prog_ann) if prog_ann else None,
     )
     
     container = client.V1Container(

--- a/src/api/app/routes/workflows.py
+++ b/src/api/app/routes/workflows.py
@@ -10,6 +10,7 @@ import uuid
 import os
 
 from repository import WorkflowRepository, WorkflowDefinitionRepository
+from repository.program_repo import ProgramRepository
 from models.workflow import (
     WorkflowRequest,
     WorkflowCreateResponse,
@@ -1049,7 +1050,14 @@ async def list_queue_workloads(
 ):
     """List all workloads in the queue"""
     try:
-        workloads = k8s_service.list_workloads(program_name)
+        program_id = None
+        if program_name and program_name.strip():
+            prog = await ProgramRepository.get_program_by_name(program_name.strip())
+            if not prog:
+                return WorkloadListResponse(workloads=[], count=0)
+            program_id = prog["id"]
+
+        workloads = k8s_service.list_workloads(program_id=program_id)
         
         # Filter workloads based on user permissions
         accessible_workloads = []

--- a/src/api/app/services/kubernetes.py
+++ b/src/api/app/services/kubernetes.py
@@ -4,10 +4,15 @@ from kubernetes.stream import stream
 import os
 import logging
 import json
-from typing import Dict, Any, List, Optional
+from typing import Dict, Any, List, Optional, Tuple
 from repository import AdminRepository
+from repository.program_repo import ProgramRepository
 
 logger = logging.getLogger(__name__)
+
+# Workflow Job/Workload: never put raw program name in labels (Kubernetes max 63 chars).
+WORKFLOW_PROGRAM_NAME_ANNOTATION = "reconhawx.io/program-name"
+WORKFLOW_PROGRAM_ID_LABEL = "program-id"
 
 # Suppress noisy filelock DEBUG logs and tldextract filelock logs
 logging.getLogger("kubernetes.client.rest").setLevel(logging.WARNING)
@@ -60,6 +65,31 @@ class KubernetesService:
         }
 
         logger.info(f"KubernetesService initialized - Kueue enabled: {self.kueue_enabled}")
+
+    @staticmethod
+    def _workflow_program_metadata_fragments(
+        workflow_data: Dict[str, Any],
+    ) -> Tuple[Dict[str, str], Dict[str, str]]:
+        """Extra labels/annotations for program on workflow Jobs and Kueue Workloads."""
+        labels: Dict[str, str] = {}
+        annotations: Dict[str, str] = {}
+        program_name = (workflow_data.get("program_name") or "").strip()
+        program_id = workflow_data.get("program_id")
+        if program_id:
+            labels[WORKFLOW_PROGRAM_ID_LABEL] = str(program_id)
+        if program_name:
+            annotations[WORKFLOW_PROGRAM_NAME_ANNOTATION] = program_name
+        return labels, annotations
+
+    @staticmethod
+    def _program_name_from_workload_metadata(metadata: Dict[str, Any]) -> str:
+        labels = (metadata or {}).get("labels") or {}
+        annotations = (metadata or {}).get("annotations") or {}
+        return (
+            annotations.get(WORKFLOW_PROGRAM_NAME_ANNOTATION)
+            or labels.get("program")
+            or ""
+        )
 
     async def _get_aws_credentials(self) -> Optional[Dict[str, str]]:
         """
@@ -240,7 +270,7 @@ class KubernetesService:
                     logger.error(f"Failed to create ConfigMap: {e}")
                     raise
             
-            # Create workload metadata
+            prog_labels, prog_ann = self._workflow_program_metadata_fragments(workflow_data)
             workload_metadata = {
                 "name": f"workflow-{execution_id}",
                 "namespace": namespace,
@@ -248,9 +278,10 @@ class KubernetesService:
                     "app": "workflow-runner",
                     "workflow-id": execution_id,
                     "execution-id": execution_id,
-                    "program": workflow_data['program_name'],
-                    "priority": priority
-                }
+                    "priority": priority,
+                    **prog_labels,
+                },
+                "annotations": dict(prog_ann),
             }
             
             # Create pod template (same as before but with resource requirements)
@@ -366,6 +397,9 @@ class KubernetesService:
             {"name": "TYPOSQUAT_CACHE_TTL", "value": os.getenv('TYPOSQUAT_CACHE_TTL', '2592000')},
             {"name": "TYPOSQUAT_USE_CACHE", "value": os.getenv('TYPOSQUAT_USE_CACHE', 'true')}
         ]
+        _program_uuid = workflow_data.get("program_id")
+        if _program_uuid:
+            env_vars.insert(3, {"name": "PROGRAM_ID", "value": str(_program_uuid)})
 
         # Add AWS credentials if available
         if aws_creds:
@@ -537,15 +571,15 @@ class KubernetesService:
             logger.error(f"Error getting queue position: {e}")
             return -1
 
-    def list_workloads(self, program_name: str = None) -> List[Dict[str, Any]]:
-        """List all workflow workloads with optional filtering"""
+    def list_workloads(self, program_id: Optional[str] = None) -> List[Dict[str, Any]]:
+        """List all workflow workloads with optional filtering by program UUID label."""
         try:
             namespace = os.getenv('KUBERNETES_NAMESPACE', 'default')
             
-            # Build label selector
+            # Build label selector (program name is not a label — use program-id)
             label_selector = "app=workflow-runner"
-            if program_name:
-                label_selector += f",program={program_name}"
+            if program_id:
+                label_selector += f",{WORKFLOW_PROGRAM_ID_LABEL}={program_id}"
             
             workloads = self.custom_objects_v1.list_namespaced_custom_object(
                 group="kueue.x-k8s.io",
@@ -561,10 +595,11 @@ class KubernetesService:
                 execution_id = workload.get('metadata', {}).get('name', '').replace('workflow-', '')
                 status_info = self.get_workload_status(execution_id)
                 
+                meta = workload.get('metadata', {}) or {}
                 processed_workload = {
                     'execution_id': execution_id,
-                    'workflow_id': workload.get('metadata', {}).get('labels', {}).get('workflow-id', ''),
-                    'program_name': workload.get('metadata', {}).get('labels', {}).get('program', ''),
+                    'workflow_id': (meta.get('labels') or {}).get('workflow-id', ''),
+                    'program_name': self._program_name_from_workload_metadata(meta),
                     'priority': workload.get('spec', {}).get('priority', 5),
                     'queue_name': workload.get('spec', {}).get('queueName', ''),
                     'created_at': workload.get('metadata', {}).get('creationTimestamp', ''),
@@ -679,6 +714,18 @@ class KubernetesService:
     async def create_runner_job(self, workflow_data: Dict[str, Any]):
         """Create a Kubernetes job for workflow execution with Kueue support"""
         try:
+            program_name = (workflow_data.get("program_name") or "").strip()
+            if program_name and not workflow_data.get("program_id"):
+                prog = await ProgramRepository.get_program_by_name(program_name)
+                if prog:
+                    workflow_data["program_id"] = prog["id"]
+                else:
+                    logger.warning(
+                        "No DB program for program_name=%r; omitting %s label on workflow Job",
+                        program_name,
+                        WORKFLOW_PROGRAM_ID_LABEL,
+                    )
+
             # If Kueue is enabled, create job with Kueue annotations
             if self.kueue_enabled:
                 logger.info("Kueue enabled, creating job with Kueue annotations")
@@ -758,6 +805,12 @@ class KubernetesService:
             
             # Create Kubernetes Job with Kueue annotations
             job_name = f"workflow-{execution_id}"
+            prog_labels, prog_ann = self._workflow_program_metadata_fragments(workflow_data)
+            job_annotations = {
+                "kueue.x-k8s.io/queue-name": self.kueue_workflow_queue,
+                "kueue.x-k8s.io/priority-class": self.kueue_priority_class,
+                **prog_ann,
+            }
             job = {
                 "apiVersion": "batch/v1",
                 "kind": "Job",
@@ -768,13 +821,10 @@ class KubernetesService:
                         "app": "workflow-runner",
                         "execution-id": execution_id,
                         "workflow-id": execution_id,
-                        "program": workflow_data.get('program_name', ''),
-                        "priority": workflow_data.get('priority', 'normal')
+                        "priority": workflow_data.get('priority', 'normal'),
+                        **prog_labels,
                     },
-                    "annotations": {
-                        "kueue.x-k8s.io/queue-name": self.kueue_workflow_queue,
-                        "kueue.x-k8s.io/priority-class": self.kueue_priority_class
-                    }
+                    "annotations": job_annotations,
                 },
                 "spec": {
                     "parallelism": 1,
@@ -878,7 +928,7 @@ class KubernetesService:
                     logger.error(f"Failed to create ConfigMap: {e}")
                     raise
             
-            # Create job metadata
+            prog_labels, prog_ann = self._workflow_program_metadata_fragments(workflow_data)
             metadata = client.V1ObjectMeta(
                 name=f"workflow-{execution_id}",
                 namespace=namespace,
@@ -886,8 +936,9 @@ class KubernetesService:
                     "app": "workflow-runner",
                     "workflow-id": execution_id,
                     "execution-id": execution_id,
-                    "program": workflow_data['program_name']
-                }
+                    **prog_labels,
+                },
+                annotations=dict(prog_ann) if prog_ann else None,
             )
             
             # Fetch AWS credentials from database
@@ -948,6 +999,9 @@ class KubernetesService:
                 client.V1EnvVar(name="TYPOSQUAT_CACHE_TTL", value=os.getenv('TYPOSQUAT_CACHE_TTL', '2592000')),
                 client.V1EnvVar(name="TYPOSQUAT_USE_CACHE", value=os.getenv('TYPOSQUAT_USE_CACHE', 'true'))
             ]
+            _program_uuid = workflow_data.get("program_id")
+            if _program_uuid:
+                env_vars.insert(3, client.V1EnvVar(name="PROGRAM_ID", value=str(_program_uuid)))
 
             # Add AWS credentials if available
             if aws_creds:

--- a/src/api/tests/test_workflow_k8s_program_metadata.py
+++ b/src/api/tests/test_workflow_k8s_program_metadata.py
@@ -1,0 +1,31 @@
+"""Unit tests for workflow Job/Workload program metadata (Kubernetes label limits)."""
+
+from services.kubernetes import (
+    KubernetesService,
+    WORKFLOW_PROGRAM_ID_LABEL,
+    WORKFLOW_PROGRAM_NAME_ANNOTATION,
+)
+
+
+def test_workflow_program_metadata_uses_id_label_and_name_annotation():
+    long_name = "YWH_programme-prive-de-prime-aux-bogues-du-gouvernement-du-quebec-extra"
+    program_id = "90c18002-e669-4bd8-a9f5-b7ecbb439b2f"
+    wf = {"program_name": long_name, "program_id": program_id}
+    labels, annotations = KubernetesService._workflow_program_metadata_fragments(wf)
+    assert labels.get(WORKFLOW_PROGRAM_ID_LABEL) == program_id
+    assert annotations.get(WORKFLOW_PROGRAM_NAME_ANNOTATION) == long_name
+    assert "program" not in labels
+    assert all(len(v) <= 63 for v in labels.values())
+
+
+def test_program_name_from_metadata_prefers_annotation_over_legacy_label():
+    meta = {
+        "labels": {"program": "short-legacy"},
+        "annotations": {WORKFLOW_PROGRAM_NAME_ANNOTATION: "full-from-annotation"},
+    }
+    assert KubernetesService._program_name_from_workload_metadata(meta) == "full-from-annotation"
+
+
+def test_program_name_from_metadata_legacy_label_fallback():
+    meta = {"labels": {"program": "legacy-only"}, "annotations": {}}
+    assert KubernetesService._program_name_from_workload_metadata(meta) == "legacy-only"

--- a/src/runner/app/recon_tasks/base.py
+++ b/src/runner/app/recon_tasks/base.py
@@ -1229,10 +1229,12 @@ class Task(ABC):
         safe_task_name = task_name.replace('_', '-').lower()
         job_name = kwargs.get('job_name', f"{safe_task_name}-{str(uuid.uuid4())[:8]}")
 
+        program_id = (os.getenv("PROGRAM_ID") or "").strip()
         job_params = {
             "workflow_id": execution_id,
-            "workflow_name": program_name,
+            "workflow_name": os.getenv("WORKFLOW_NAME") or program_name,
             "program_name": program_name,
+            **({"program_id": program_id} if program_id else {}),
             "task_name": safe_task_name,
             "step_num": kwargs.get('step_num', 0),
             "step_name": kwargs.get('step_name', f"{safe_task_name}-chunk"),
@@ -1316,10 +1318,12 @@ class Task(ABC):
             safe_step_name = f"{safe_task_name}-spawned-{int(time.time())}"
             safe_job_name = f"spawned-{safe_task_name}-{str(uuid.uuid4())[:8]}"
             
+            program_id_spawn = (os.getenv("PROGRAM_ID") or "").strip()
             job_params = {
                 "workflow_id": execution_id,  # Use execution_id for output routing
-                "workflow_name": program_name,
+                "workflow_name": os.getenv("WORKFLOW_NAME") or program_name,
                 "program_name": program_name,
+                **({"program_id": program_id_spawn} if program_id_spawn else {}),
                 "task_name": safe_task_name,
                 "step_num": 0,
                 "step_name": safe_step_name,

--- a/src/runner/app/services/kubernetes.py
+++ b/src/runner/app/services/kubernetes.py
@@ -1,11 +1,48 @@
 import logging
+import re
 from kubernetes import client, config
 from kubernetes.client.rest import ApiException
-from typing import Dict, Any, List
+from typing import Dict, Any, List, Tuple
 import os
 import uuid
 import asyncio
+
 logger = logging.getLogger(__name__)
+
+# Align with API workflow Jobs: label values max 63 chars — never put raw program name in labels.
+WORKFLOW_PROGRAM_NAME_ANNOTATION = "reconhawx.io/program-name"
+WORKFLOW_PROGRAM_ID_LABEL = "program-id"
+
+# Kubernetes label values: max 63 chars; must match
+# (([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?  (non-empty must start/end alphanumeric).
+_K8S_LABEL_VALUE_MAX_LEN = 63
+
+
+def _sanitize_k8s_label_value(value: Any) -> str:
+    """Produce a valid Kubernetes label value for display-ish fields (workflow/step names)."""
+    s = "" if value is None else str(value)
+    if not s:
+        return ""
+    # Replace any run of invalid characters with a single hyphen
+    s = re.sub(r"[^A-Za-z0-9_.-]+", "-", s)
+    s = re.sub(r"-{2,}", "-", s).strip("-_.")
+    while s and (not s[0].isalnum() or not s[-1].isalnum()):
+        if not s[0].isalnum():
+            s = s[1:]
+        elif not s[-1].isalnum():
+            s = s[:-1]
+        else:
+            break
+    if not s:
+        return "na"
+    if len(s) > _K8S_LABEL_VALUE_MAX_LEN:
+        s = s[:_K8S_LABEL_VALUE_MAX_LEN]
+        while s and not s[-1].isalnum():
+            s = s[:-1]
+        if not s:
+            return "na"
+    return s
+
 
 class KubernetesService:
     def __init__(self):
@@ -18,7 +55,20 @@ class KubernetesService:
         self.core_api = client.CoreV1Api()
         self.kubernetes_namespace = os.getenv('KUBERNETES_NAMESPACE', '')
         self.docker_registry = os.getenv('DOCKER_REGISTRY', '')
-        
+
+    @staticmethod
+    def _worker_program_k8s_fragments(job_params: Dict[str, Any]) -> Tuple[Dict[str, str], Dict[str, str]]:
+        """Labels and annotations for program on worker Jobs (avoid long names in labels)."""
+        labels: Dict[str, str] = {}
+        annotations: Dict[str, str] = {}
+        program_name = (job_params.get("program_name") or "").strip()
+        program_id = job_params.get("program_id")
+        if program_id:
+            labels[WORKFLOW_PROGRAM_ID_LABEL] = str(program_id)
+        if program_name:
+            annotations[WORKFLOW_PROGRAM_NAME_ANNOTATION] = program_name
+        return labels, annotations
+
     def get_pod_logs(self, type: str, id: str) -> str:
         """Get logs from a pod even if it failed"""
         try:
@@ -158,6 +208,7 @@ class KubernetesService:
         """
         Generate an equivalent job CRD to sample-job.yaml
         """
+        prog_labels, prog_ann = self._worker_program_k8s_fragments(job_params)
         metadata = client.V1ObjectMeta(
             name=f"worker-{job_params['job_id']}",
             labels={
@@ -165,12 +216,13 @@ class KubernetesService:
                 "app": "worker",
                 "task-id": job_params["job_id"],
                 "workflow-id": job_params["workflow_id"],
-                "workflow-name": job_params["workflow_name"],
-                "program-name": job_params["program_name"],
-                "task-name": job_params["task_name"],
+                "workflow-name": _sanitize_k8s_label_value(job_params["workflow_name"]),
+                "task-name": _sanitize_k8s_label_value(job_params["task_name"]),
                 "step-num": str(job_params["step_num"]),
-                "step-name": job_params["step_name"]
-            }
+                "step-name": _sanitize_k8s_label_value(job_params["step_name"]),
+                **prog_labels,
+            },
+            annotations=dict(prog_ann) if prog_ann else None,
         )
 
         # Always use sh -c to avoid JSON marshaling issues with args array
@@ -241,18 +293,20 @@ class KubernetesService:
             }
         }
 
-        # Job template
+        # Job template (pod labels must also respect 63-char limit on values)
         template = client.V1PodTemplateSpec(
             metadata=client.V1ObjectMeta(
                 labels={
                     "app": "worker",
                     "task-id": job_params["job_id"],
                     "workflow-id": job_params["workflow_id"],
-                    "program-name": job_params["program_name"],
-                    "task-name": job_params["task_name"],
+                    "workflow-name": _sanitize_k8s_label_value(job_params["workflow_name"]),
+                    "task-name": _sanitize_k8s_label_value(job_params["task_name"]),
                     "step-num": str(job_params["step_num"]),
-                    "step-name": job_params["step_name"]
-                }
+                    "step-name": _sanitize_k8s_label_value(job_params["step_name"]),
+                    **prog_labels,
+                },
+                annotations=dict(prog_ann) if prog_ann else None,
             ),
             spec=client.V1PodSpec(
                 containers=[container],

--- a/src/runner/app/worker_job_manager.py
+++ b/src/runner/app/worker_job_manager.py
@@ -143,6 +143,7 @@ class WorkerJobManager:
         self.workflow_id = os.getenv('WORKFLOW_ID', 'unknown')
         self.execution_id = os.getenv('EXECUTION_ID', self.workflow_id)
         self.program_name = os.getenv('PROGRAM_NAME', 'default')
+        self.program_id = (os.getenv('PROGRAM_ID') or '').strip()
     
     def _ensure_k8s_service(self):
         """Lazily initialize KubernetesService if not provided"""
@@ -193,8 +194,9 @@ class WorkerJobManager:
         
         job_params = {
             "workflow_id": self.execution_id,  # Use execution_id for output routing
-            "workflow_name": self.program_name,
+            "workflow_name": os.getenv("WORKFLOW_NAME") or self.program_name,
             "program_name": self.program_name,
+            **({"program_id": self.program_id} if self.program_id else {}),
             "task_name": safe_task_name,
             "step_num": kwargs.get('step_num', 0),
             "step_name": kwargs.get('step_name', f"{safe_task_name}-{int(time.time())}"),

--- a/src/runner/tests/services/test_services_kubernetes.py
+++ b/src/runner/tests/services/test_services_kubernetes.py
@@ -6,9 +6,12 @@ selectors, job-status mapping, and job-CRD generation.
 
 from __future__ import annotations
 
+import re
 from unittest.mock import MagicMock
 
 import pytest
+
+import services.kubernetes as k8s_mod
 
 
 @pytest.fixture
@@ -81,6 +84,7 @@ def test_generate_job_crd_sets_labels_and_env(svc, monkeypatch) -> None:
         "workflow_id": "wf-1",
         "workflow_name": "my-wf",
         "program_name": "prog",
+        "program_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
         "task_name": "resolve_ip",
         "step_num": 1,
         "step_name": "resolve",
@@ -92,6 +96,9 @@ def test_generate_job_crd_sets_labels_and_env(svc, monkeypatch) -> None:
     crd = svc.generate_job_crd(job_params)
     assert crd.metadata.name == "worker-job-1"
     assert crd.metadata.labels["task-id"] == "job-1"
+    assert crd.metadata.labels.get("program-id") == "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    assert "program-name" not in crd.metadata.labels
+    assert crd.metadata.annotations.get("reconhawx.io/program-name") == "prog"
     assert crd.metadata.labels["kueue.x-k8s.io/queue-name"] == "recon-worker-queue"
     assert crd.spec.active_deadline_seconds == 1200
     assert crd.spec.suspend is True
@@ -103,7 +110,70 @@ def test_generate_job_crd_sets_labels_and_env(svc, monkeypatch) -> None:
     assert env_by_name["TASK_ID"] == "job-1"
     assert env_by_name["OUTPUT_QUEUE_SUBJECT"] == "tasks.output.wf-1"
     assert env_by_name["WORKFLOW_ID"] == "wf-1"
+    assert env_by_name["PROGRAM_NAME"] == "prog"
     assert env_by_name["STEP_NUM"] == "1"
+    tpl = crd.spec.template.metadata
+    assert tpl.labels.get("program-id") == "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    assert tpl.annotations.get("reconhawx.io/program-name") == "prog"
+
+
+def test_sanitize_k8s_label_value_removes_spaces() -> None:
+    out = k8s_mod._sanitize_k8s_label_value("Single Task Run - resolve_domain")
+    assert " " not in out
+    assert re.match(r"^[A-Za-z0-9].*[A-Za-z0-9]$", out)
+    assert len(out) <= 63
+
+
+def test_generate_job_crd_workflow_name_with_spaces_is_valid_label(svc, monkeypatch) -> None:
+    monkeypatch.setenv("API_URL", "http://api:8000")
+    monkeypatch.setenv("NATS_URL", "nats://nats:4222")
+    monkeypatch.setenv("IMAGE_PULL_POLICY", "IfNotPresent")
+    job_params = {
+        "job_id": "j-ws",
+        "workflow_id": "wf-ws",
+        "workflow_name": "Single Task Run - resolve_domain",
+        "program_name": "prog",
+        "task_name": "resolve_domain",
+        "step_num": 0,
+        "step_name": "step 1 / test",
+        "args": ["echo hi"],
+        "image": "img",
+        "job_name": "jn",
+        "timeout": 60,
+    }
+    crd = svc.generate_job_crd(job_params)
+    for k, v in crd.metadata.labels.items():
+        assert len(v) <= 63, k
+        if v:
+            assert re.match(r"^([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$", v), (k, v)
+    for k, v in crd.spec.template.metadata.labels.items():
+        assert len(v) <= 63, k
+        if v:
+            assert re.match(r"^([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$", v), (k, v)
+
+
+def test_generate_job_crd_long_program_name_not_in_labels(svc) -> None:
+    long_name = "YWH_programme-prive-de-prime-aux-bogues-du-gouvernement-du-quebec"
+    pid = "90c18002-e669-4bd8-a9f5-b7ecbb439b2f"
+    job_params = {
+        "job_id": "job-2",
+        "workflow_id": "wf-2",
+        "workflow_name": "wf",
+        "program_name": long_name,
+        "program_id": pid,
+        "task_name": "t",
+        "step_num": 0,
+        "step_name": "s",
+        "args": ["echo hi"],
+        "image": "img",
+        "job_name": "jn",
+        "timeout": 60,
+    }
+    crd = svc.generate_job_crd(job_params)
+    assert "program-name" not in crd.metadata.labels
+    assert all(len(v) <= 63 for v in crd.metadata.labels.values())
+    assert crd.metadata.annotations["reconhawx.io/program-name"] == long_name
+    assert crd.spec.template.metadata.labels.get("program-id") == pid
 
 
 def test_generate_job_crd_quotes_commands_with_pipes(svc) -> None:

--- a/src/runner/tests/test_worker_job_manager.py
+++ b/src/runner/tests/test_worker_job_manager.py
@@ -75,6 +75,13 @@ def test_make_rfc1123_compliant(mgr: WorkerJobManager, given: str, expected: str
     assert mgr._make_rfc1123_compliant(given) == expected
 
 
+def test_build_job_params_includes_program_id_when_set(mgr: WorkerJobManager, monkeypatch) -> None:
+    monkeypatch.setenv("PROGRAM_ID", "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+    mgr._refresh_environment_context()
+    params = mgr._build_job_params("resolve_ip", "echo hi")
+    assert params.get("program_id") == "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+
 def test_build_job_params_injects_required_env(mgr: WorkerJobManager, monkeypatch) -> None:
     monkeypatch.setenv("WORKER_IMAGE", "worker:0.1")
     params = mgr._build_job_params("resolve_ip", "echo hi", timeout=60, step_num=3)


### PR DESCRIPTION
…orker jobs

API workflow Jobs use program-id and reconhawx.io/program-name instead of a raw program label; create_runner_job resolves program_id from Postgres. Runner pods receive PROGRAM_ID when present. Queue workload listing filters by program-id after resolving the program row.

Runner worker Jobs use the same program-id/annotation pattern, WORKFLOW_NAME for workflow-name labels where appropriate, and sanitized label values for workflow/step fields so spaces and other invalid characters cannot fail admission.

Tests and Cursor rules document the behavior.

Made-with: Cursor