### PR TITLE
fix(runner): quote worker shell commands safely for kubectl Jobs

### DIFF
--- a/src/runner/app/recon_tasks/test_http.py
+++ b/src/runner/app/recon_tasks/test_http.py
@@ -9,6 +9,21 @@ from urllib.parse import urlparse
 import dns.resolver
 logger = logging.getLogger(__name__)
 
+# httpx `-p`: probe both schemes per port range via explicit http:/https: pairs — avoids shell `&`
+# when the runner passes the command through ``sh`` (Kubernetes worker Job).
+_HTTPX_DOMAIN_PORT_SPEC = (
+    "http:80-99,https:80-99,"
+    "http:443-449,https:443-449,"
+    "http:11443,https:11443,"
+    "http:8443-8449,https:8443-8449,"
+    "http:9000-9003,https:9000-9003,"
+    "http:8080-8089,https:8080-8089,"
+    "http:8801-8810,https:8801-8810,"
+    "http:3000,https:3000,"
+    "http:5000,https:5000"
+)
+
+
 class TestHTTP(Task):
     name = "test_http"
     description = "Test HTTP"
@@ -45,7 +60,9 @@ class TestHTTP(Task):
         if len(domains_to_process) > 0:
             domains_text = '\n'.join(domains_to_process)
             commands.append(
-                f"cat << 'EOF' | httpx -fr -maxr 10 -include-chain -silent -status-code -content-length -tech-detect -threads 50 -no-color -json -efqdn -tls-grab -pa -pipeline -http2 -bp -ip -cname -asn -random-agent -favicon -hash sha256 -p 80-99,443-449,11443,8443-8449,9000-9003,8080-8089,8801-8810,3000,5000\n{domains_text}\nEOF"
+                f"cat << 'EOF' | httpx -fr -maxr 10 -include-chain -silent -status-code -content-length -tech-detect -threads 50 -no-color -json -efqdn -tls-grab -pa -pipeline -http2 -bp -ip -cname -asn -random-agent -favicon -hash sha256 "
+                f"-p {_HTTPX_DOMAIN_PORT_SPEC} "
+                f"-fs 'The plain HTTP request was sent to HTTPS port'\n{domains_text}\nEOF"
             )
 
         # Return array of commands to spawn separate worker jobs

--- a/src/runner/app/services/kubernetes.py
+++ b/src/runner/app/services/kubernetes.py
@@ -1,5 +1,6 @@
 import logging
 import re
+import shlex
 from kubernetes import client, config
 from kubernetes.client.rest import ApiException
 from typing import Dict, Any, List, Tuple
@@ -228,8 +229,8 @@ class KubernetesService:
         # Always use sh -c to avoid JSON marshaling issues with args array
         shell_command = job_params["args"][0] if job_params["args"] else ""
 
-        # Properly quote the shell command to handle pipes and special characters
-        quoted_command = f"'{shell_command}'" if '|' in shell_command or '&' in shell_command else shell_command
+        # Safe for ``sh -c``: embedded ``'`` (e.g. heredoc ``<< 'EOF'``), ``&``, ``|``, etc.
+        quoted_command = shlex.quote(shell_command)
 
         container = client.V1Container(
             image=job_params["image"],

--- a/src/runner/tests/services/test_services_kubernetes.py
+++ b/src/runner/tests/services/test_services_kubernetes.py
@@ -7,6 +7,7 @@ selectors, job-status mapping, and job-CRD generation.
 from __future__ import annotations
 
 import re
+import shlex
 from unittest.mock import MagicMock
 
 import pytest
@@ -117,6 +118,30 @@ def test_generate_job_crd_sets_labels_and_env(svc, monkeypatch) -> None:
     tpl = crd.spec.template.metadata
     assert tpl.labels.get("program-id") == "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
     assert tpl.annotations.get("reconhawx.io/program-name") == "prog"
+
+
+def test_generate_job_crd_escapes_worker_shell_command_with_shlex(svc, monkeypatch) -> None:
+    """Embedded ``'`` (heredoc / ``-fs``) must not break ``sh -c``; see worker Job + httpx."""
+    monkeypatch.setenv("API_URL", "http://api:8000")
+    monkeypatch.setenv("NATS_URL", "nats://nats:4222")
+    monkeypatch.setenv("IMAGE_PULL_POLICY", "IfNotPresent")
+    shell_like = "cat << 'EOF' | httpx -p 'a&b|c' -fs 'plain text'\nhost\nEOF"
+    job_params = {
+        "job_id": "jq-1",
+        "workflow_id": "wf-q",
+        "workflow_name": "w",
+        "program_name": "p",
+        "task_name": "t",
+        "step_num": 0,
+        "step_name": "s",
+        "args": [shell_like],
+        "image": "img",
+        "job_name": "jn",
+        "timeout": 60,
+    }
+    crd = svc.generate_job_crd(job_params)
+    quoted = shlex.quote(shell_like)
+    assert crd.spec.template.spec.containers[0].command[2].endswith(quoted)
 
 
 def test_sanitize_k8s_label_value_removes_spaces() -> None:


### PR DESCRIPTION
Kubernetes worker Jobs pass the subprocess command through ``sh -c``; wrapping arguments in naive ``'…'`` broke when commands contained pipes, ampersands, or inner single quotes (heredocs, ``-p`` / ``-fs``). Use ``shlex.quote`` for the wrapper argv.

For ``test_http`` subdomain input, probe explicit ``http:/https:`` port ranges and keep the plaintext response filter aligned with httpx.

Regression test asserts Job CRDs embed correctly quoted shell payloads.

Made-with: Cursor