### PR TITLE
fix(runner): restore typosquat ingest for scheduled gather API findin…

### DIFF
--- a/.cursor/rules/gather-typosquat-vendor-api.mdc
+++ b/.cursor/rules/gather-typosquat-vendor-api.mdc
@@ -32,7 +32,7 @@ Register new vendors in `GatherApiFindingsTask._create_vendor_adapter` and imple
 ## Finding shape and API
 
 - Per domain: `vendor_adapter.create_finding_data(domain_data, program_name)` produces `{typo_domain, program_name, source, ...}` plus `{vendor}_data` JSONB payload.
-- **Batch create**: POST `{api_base}/findings/typosquat` with wrapped `findings.typosquat_domain[]`.
+- **Batch create**: POST `{api_base}/findings/typosquat` with top-level **`program_id`** (UUID) and optional `program_name`; body wraps `findings.typosquat_domain[]`. Scheduled `gather_api_findings` jobs receive `program_id` from the schedule row (`program_ids[0]`) in the K8s ConfigMap; if missing (older payloads), the task falls back to GET `/programs/{name}`.
 - **Patches** (updates / enrichment): `PATCH .../typosquat/{id}/recordedfuture-data`, `PATCH .../threatstream-data`, `PATCH .../recordedfuture-derived-columns` (API routes under `/findings`).
 
 WHOIS-related fields in create/update payloads are stored on **`typosquat_apex_domains`** (registrable domain per program); API responses merge those fields onto each finding as flat `whois_*` keys.

--- a/src/api/app/services/job_scheduler.py
+++ b/src/api/app/services/job_scheduler.py
@@ -458,11 +458,14 @@ class JobSchedulerService:
                 await JobRepository.create_job(job_id, request.job_type.value, job_payload)
 
                 if request.job_type == JobType.GATHER_API_FINDINGS:
+                    _pids = job_row.get("program_ids") or []
+                    _first_program_id = str(_pids[0]) if _pids else None
                     worker_payload = {
                         "job_id": job_id,
                         "job_type": request.job_type.value,
                         "schedule_id": schedule_id,
                         "user_id": job_row["user_id"],
+                        "program_id": _first_program_id,
                         "program_name": request.program_name,
                         "created_at": datetime.now(timezone.utc).isoformat(),
                         "job_data": effective_job_data,

--- a/src/runner/app/batch_jobs/gather_api_findings.py
+++ b/src/runner/app/batch_jobs/gather_api_findings.py
@@ -11,13 +11,25 @@ logger = logging.getLogger(__name__)
 class GatherApiFindingsTask:
     """Task for gathering typosquat domain findings from vendor APIs"""
 
-    def __init__(self, job_id: str, program_name: str, user_id: str, api_vendor: str = "threatstream", date_range_hours: Optional[int] = None, custom_query: Optional[str] = None):
+    def __init__(
+        self,
+        job_id: str,
+        program_name: str,
+        user_id: str,
+        api_vendor: str = "threatstream",
+        date_range_hours: Optional[int] = None,
+        custom_query: Optional[str] = None,
+        program_id: Optional[str] = None,
+    ):
         self.job_id = job_id
         self.program_name = program_name
         self.user_id = user_id
         self.api_vendor = api_vendor
         self.date_range_hours = date_range_hours
         self.custom_query = custom_query
+        self.program_id = (
+            str(program_id).strip() if program_id and str(program_id).strip() else None
+        )
         self.existing_domains_cache = set()  # Cache existing domains for the single program
         self.results = {
             "success_count": 0,
@@ -55,6 +67,9 @@ class GatherApiFindingsTask:
         logger.info(f"Full endpoint URL will be: {self.api_base_url}/findings/typosquat")
         logger.info(f"Target API vendor: {api_vendor}")
         logger.info(f"Target program: {program_name}")
+        logger.info(
+            f"Target program_id: {self.program_id if self.program_id else '(unset; will resolve via API if needed)'}"
+        )
         if date_range_hours is not None:
             if date_range_hours == 0:
                 logger.info("Date range filter: 0 hours (no date filtering - fetch all available data)")
@@ -76,6 +91,8 @@ class GatherApiFindingsTask:
 
             # Test API connectivity first
             await self.test_api_connectivity()
+
+            await self._ensure_program_id()
 
             # Pre-fetch existing domains for the program
             await self.fetch_existing_domains_for_program(self.program_name)
@@ -148,6 +165,36 @@ class GatherApiFindingsTask:
         if self.connector and not self.connector.closed:
             await self.connector.close()
             logger.debug("Closed HTTP connector")
+    
+    async def _ensure_program_id(self) -> str:
+        """Resolve and cache program UUID for API ingest (POST /findings/typosquat requires program_id)."""
+        if self.program_id:
+            return self.program_id
+
+        headers: Dict[str, str] = {}
+        if self.api_token:
+            headers["Authorization"] = f"Bearer {self.api_token}"
+
+        url = f"{self.api_base_url}/programs/{self.program_name}"
+        logger.info(f"Resolving program_id via GET {url}")
+        session = await self._get_session()
+        async with session.get(url, headers=headers) as response:
+            if response.status != 200:
+                response_text = await response.text()
+                raise Exception(
+                    f"Failed to resolve program_id for {self.program_name!r}: "
+                    f"HTTP {response.status} - {response_text}"
+                )
+            program_data = await response.json()
+
+        pid = program_data.get("id")
+        if not pid or not str(pid).strip():
+            raise Exception(
+                f"Program {self.program_name!r} has no id in API response; cannot ingest findings"
+            )
+        self.program_id = str(pid).strip()
+        logger.info(f"Resolved program_id={self.program_id} for program {self.program_name}")
+        return self.program_id
     
     def _apply_vendor_configuration(self):
         """Apply any runtime configuration updates to the vendor adapter"""
@@ -390,9 +437,14 @@ class GatherApiFindingsTask:
                 headers["Authorization"] = f"Bearer {self.api_token}"
 
             url = f"{self.api_base_url}/findings/typosquat"
+            if not self.program_id:
+                raise ValueError(
+                    "program_id is required to store typosquat findings; ensure execute() calls _ensure_program_id()"
+                )
             # Wrap findings in the expected API format
             batch_data = {
-                "program_name": findings[0].get("program_name") if findings else "",
+                "program_id": self.program_id,
+                "program_name": self.program_name,
                 "findings": {
                     "typosquat_domain": findings
                 }

--- a/src/runner/app/run-job.py
+++ b/src/runner/app/run-job.py
@@ -53,6 +53,7 @@ async def run_gather_api_findings_job(job_data: dict):
     try:
         job_id = job_data.get("job_id")
         program_name = job_data.get("program_name")  # Single program from scheduled job
+        program_id = job_data.get("program_id")
         user_id = job_data.get("user_id", "unknown")
 
         # Extract from job_data nested structure
@@ -82,10 +83,21 @@ async def run_gather_api_findings_job(job_data: dict):
                 )
                 return False
 
-        logger.info(f"Starting gather API findings job {job_id} for program {program_name} using {api_vendor}")
+        logger.info(
+            f"Starting gather API findings job {job_id} for program {program_name} "
+            f"(program_id={program_id!r}) using {api_vendor}"
+        )
 
         # Create and execute the task
-        task = GatherApiFindingsTask(job_id, program_name, user_id, api_vendor, date_range_hours, custom_query)
+        task = GatherApiFindingsTask(
+            job_id,
+            program_name,
+            user_id,
+            api_vendor,
+            date_range_hours,
+            custom_query,
+            program_id=program_id,
+        )
         await task.execute()
 
         logger.info(f"Gather API findings job {job_id} completed successfully")


### PR DESCRIPTION
…gs jobs

POST /findings/typosquat requires program_id; the gather job only sent program_name, so ingestion returned 400 and every domain showed "Failed to queue for processing."

Forward the schedule's program UUID (program_ids[0]) in the Kubernetes job payload, pass it through run-job into GatherApiFindingsTask, and include program_id on the batch POST. Resolve via GET /programs/{name} when program_id is absent (older payloads / split rollout).