### PR TITLE
feat(api): store hostnames and URL hosts lowercase with DB backfill

### DIFF
--- a/kubernetes/base/postgresql/schema.sql
+++ b/kubernetes/base/postgresql/schema.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
-\restrict VRgO7bKHtbJQWrhsiJ6cMvosQzTWbUYoVSIyunhewZ2nN3BZzNZrEWTyiSIAl8m
+\restrict Ei7URu6RndHzDbbtAh1tq6LEUt25x54jgyvPh33LWngezWNWpBB3lby88K5eNFn
 
 -- Dumped from database version 15.17 (Debian 15.17-1.pgdg13+1)
 -- Dumped by pg_dump version 15.17
@@ -4049,5 +4049,5 @@ ALTER TABLE ONLY public.wpscan_findings
 -- PostgreSQL database dump complete
 --
 
-\unrestrict VRgO7bKHtbJQWrhsiJ6cMvosQzTWbUYoVSIyunhewZ2nN3BZzNZrEWTyiSIAl8m
+\unrestrict Ei7URu6RndHzDbbtAh1tq6LEUt25x54jgyvPh33LWngezWNWpBB3lby88K5eNFn
 

--- a/src/api/app/repository/apexdomain_assets_repo.py
+++ b/src/api/app/repository/apexdomain_assets_repo.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 from uuid import UUID
 from sqlalchemy import and_
 
+from utils.domain_utils import normalize_hostname
 from models.postgres import (
     Program, ApexDomain, Subdomain
 )
@@ -377,8 +378,11 @@ class ApexDomainAssetsRepository(ProgramAccessMixin):
                 program = db.query(Program).filter(Program.name == apex_domain_data.get('program_name')).first()
                 if not program:
                     raise ValueError(f"Program '{apex_domain_data.get('program_name')}' not found")
-                
-                # Check if apex domain already exists for this program
+
+                if apex_domain_data.get('name') is not None:
+                    apex_domain_data['name'] = normalize_hostname(str(apex_domain_data['name'])) or apex_domain_data.get(
+                        'name'
+                    )
                 existing = db.query(ApexDomain).filter(
                     and_(ApexDomain.name == apex_domain_data.get('name'), ApexDomain.program_id == program.id)
                 ).first()

--- a/src/api/app/repository/broken_links_repo.py
+++ b/src/api/app/repository/broken_links_repo.py
@@ -9,6 +9,8 @@ from models.postgres import (
 )
 from db import get_db_session
 from utils.program_resolve import resolve_program_from_payload
+from utils.domain_utils import normalize_hostname
+from utils.url_utils import lower_url_host
 from utils.query_filters import ProgramAccessMixin
 from services.event_publisher import publisher
 
@@ -25,7 +27,12 @@ class BrokenLinksRepository(ProgramAccessMixin):
             try:
                 # Find program by name
                 program = resolve_program_from_payload(db, finding_data)
-                
+
+                if finding_data.get("domain"):
+                    finding_data["domain"] = normalize_hostname(str(finding_data["domain"]))
+                if finding_data.get("url"):
+                    finding_data["url"] = lower_url_host(str(finding_data["url"])) or finding_data["url"]
+
                 # Check if finding already exists based on unique constraint (program_id, url)
                 url = finding_data.get('url')
                 existing = None

--- a/src/api/app/repository/bulk_sql/apex_domains.py
+++ b/src/api/app/repository/bulk_sql/apex_domains.py
@@ -15,6 +15,7 @@ from models.postgres import ApexDomain, Program
 from repository.apexdomain_assets_repo import WHOIS_COLUMNS, _apply_whois_from_payload
 from repository.bulk_sql.config import sql_chunk_size
 from repository.bulk_sql.scope import domain_in_scope
+from utils.domain_utils import normalize_hostname
 
 logger = logging.getLogger(__name__)
 
@@ -50,7 +51,9 @@ def upsert_apex_domains_chunk(program_id: str, items: List[Dict[str, Any]]) -> D
             item = dict(raw)
             if not item.get("program_name"):
                 item["program_name"] = program_name_disp
-            nm = item.get("name")
+            nm = normalize_hostname(item.get("name"))
+            if nm is not None:
+                item["name"] = nm
             if not nm:
                 failed_count += 1
                 skipped_assets.append(

--- a/src/api/app/repository/bulk_sql/subdomains.py
+++ b/src/api/app/repository/bulk_sql/subdomains.py
@@ -15,7 +15,7 @@ from db import BatchSessionLocal
 from models.postgres import ApexDomain, IP, Program, Subdomain, SubdomainIP
 from repository.bulk_sql.config import sql_chunk_size
 from repository.bulk_sql.scope import domain_in_scope
-from utils.domain_utils import extract_apex_domain
+from utils.domain_utils import extract_apex_domain, normalize_hostname
 
 logger = logging.getLogger(__name__)
 
@@ -135,7 +135,13 @@ def upsert_subdomains_chunk(program_id: str, items: List[Dict[str, Any]]) -> Dic
             item = dict(raw)
             if not item.get("program_name"):
                 item["program_name"] = program_name_disp
-            hostname = item.get("name")
+            hostname = normalize_hostname(item.get("name"))
+            if hostname is not None:
+                item["name"] = hostname
+            if item.get("apex_domain"):
+                item["apex_domain"] = normalize_hostname(str(item["apex_domain"]))
+            if item.get("cname_record"):
+                item["cname_record"] = normalize_hostname(str(item["cname_record"]))
             if not hostname:
                 failed_count += 1
                 skipped_assets.append(

--- a/src/api/app/repository/bulk_sql/urls.py
+++ b/src/api/app/repository/bulk_sql/urls.py
@@ -16,6 +16,8 @@ from db import BatchSessionLocal
 from models.postgres import Program, URL
 from repository.bulk_sql.config import sql_chunk_size
 from repository.bulk_sql.scope import domain_in_scope
+from utils.domain_utils import normalize_hostname
+from utils.url_utils import lower_url_host
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +25,7 @@ logger = logging.getLogger(__name__)
 def _hostname(item: Dict[str, Any]) -> Optional[str]:
     h = item.get("hostname")
     if h:
-        return str(h).strip()
+        return normalize_hostname(str(h)) or None
     u = item.get("url")
     if not u:
         return None
@@ -73,8 +75,8 @@ def upsert_urls_chunk(program_id: str, items: List[Dict[str, Any]]) -> Dict[str,
             item = dict(raw)
             if not item.get("program_name"):
                 item["program_name"] = program_name_disp
-            u = item.get("url")
-            if not u:
+            u_raw = item.get("url")
+            if not u_raw:
                 failed_count += 1
                 skipped_assets.append(
                     {
@@ -84,18 +86,24 @@ def upsert_urls_chunk(program_id: str, items: List[Dict[str, Any]]) -> Dict[str,
                     }
                 )
                 continue
-            if u in dedup:
+            u_norm = lower_url_host(str(u_raw)) or ""
+            item["url"] = u_norm
+            if item.get("hostname"):
+                item["hostname"] = normalize_hostname(str(item["hostname"])) or item["hostname"]
+            if item.get("final_url"):
+                item["final_url"] = lower_url_host(str(item["final_url"]))
+            if u_norm in dedup:
                 failed_count += 1
                 skipped_assets.append(
                     {
-                        "url": u,
+                        "url": u_norm,
                         "program_name": program_name_disp,
                         "error": "duplicate_url_in_batch",
                     }
                 )
                 continue
-            order.append(u)
-            dedup[u] = item
+            order.append(u_norm)
+            dedup[u_norm] = item
 
         rows: List[Dict[str, Any]] = []
         meta: List[Dict[str, Any]] = []

--- a/src/api/app/repository/ip_assets_repo.py
+++ b/src/api/app/repository/ip_assets_repo.py
@@ -11,6 +11,7 @@ from models.postgres import (
 )
 from db import get_db_session
 from utils.query_filters import ProgramAccessMixin
+from utils.domain_utils import normalize_hostname
 from services.event_publisher import publisher
 from repository.program_repo import ProgramRepository
 
@@ -234,6 +235,11 @@ class IPAssetsRepository(ProgramAccessMixin):
                 program = db.query(Program).filter(Program.name == ip_data.get('program_name')).first()
                 if not program:
                     raise ValueError(f"Program '{ip_data.get('program_name')}' not found")
+
+                if ip_data.get('ptr'):
+                    ip_data['ptr'] = normalize_hostname(str(ip_data['ptr']))
+                if ip_data.get('discovered_via_domain'):
+                    ip_data['discovered_via_domain'] = normalize_hostname(str(ip_data['discovered_via_domain']))
 
                 disco = ip_data.get("discovered_via_domain")
                 if disco and not await ProgramRepository.is_domain_in_scope(disco, program.name):

--- a/src/api/app/repository/nuclei_findings_repo.py
+++ b/src/api/app/repository/nuclei_findings_repo.py
@@ -11,6 +11,8 @@ from db import get_db_session
 # Direct import to avoid circular import
 from utils.query_filters import QueryFilterUtils, ProgramAccessMixin
 from utils.program_resolve import resolve_program_from_payload
+from utils.domain_utils import normalize_hostname
+from utils.url_utils import lower_url_host
 from services.event_publisher import publisher
 
 logger = logging.getLogger(__name__)
@@ -25,7 +27,18 @@ class NucleiFindingsRepository(ProgramAccessMixin):
         async with get_db_session() as db:
             try:
                 program = resolve_program_from_payload(db, finding_data)
-                
+
+                if finding_data.get("url"):
+                    finding_data["url"] = lower_url_host(str(finding_data["url"])) or finding_data["url"]
+                if finding_data.get("hostname"):
+                    finding_data["hostname"] = normalize_hostname(str(finding_data["hostname"]))
+                if finding_data.get("template_url") and isinstance(finding_data["template_url"], str):
+                    tu = finding_data["template_url"]
+                    if tu.startswith(("http://", "https://")):
+                        finding_data["template_url"] = lower_url_host(tu) or tu
+                if finding_data.get("scheme") and isinstance(finding_data["scheme"], str):
+                    finding_data["scheme"] = finding_data["scheme"].lower()
+
                 # Find IP if provided
                 ip = None
                 if finding_data.get('ip'):

--- a/src/api/app/repository/subdomain_assets_repo.py
+++ b/src/api/app/repository/subdomain_assets_repo.py
@@ -5,7 +5,7 @@ import logging
 from .program_repo import ProgramRepository
 from datetime import datetime, timezone
 from uuid import UUID
-from utils.domain_utils import extract_apex_domain
+from utils.domain_utils import extract_apex_domain, normalize_hostname
 from models.postgres import (
     Program, ApexDomain, Subdomain, IP, SubdomainIP
 )
@@ -60,9 +60,10 @@ class SubdomainAssetsRepository(ProgramAccessMixin):
     async def get_domain_by_name(domain_name: str, programs: Optional[List[str]] = None) -> Optional[Dict[str, Any]]:
         """Get domain (subdomain) by name. If programs specified, restrict to those programs."""
         domain_id = None
+        dn = normalize_hostname(domain_name) or domain_name
         async with get_db_session() as db:
             try:
-                query = db.query(Subdomain).join(Program).filter(Subdomain.name == domain_name)
+                query = db.query(Subdomain).join(Program).filter(Subdomain.name == dn)
                 if programs is not None and len(programs) > 0:
                     query = query.filter(Program.name.in_(programs))
                 domain = query.first()
@@ -86,6 +87,10 @@ class SubdomainAssetsRepository(ProgramAccessMixin):
                 
                 for key, value in domain_data.items():
                     if hasattr(domain, key):
+                        if key == "name" and value:
+                            value = normalize_hostname(str(value)) or value
+                        if key == "cname_record" and value:
+                            value = normalize_hostname(str(value)) or value
                         setattr(domain, key, value)
                 
                 domain.updated_at = datetime.now(timezone.utc)
@@ -316,12 +321,19 @@ class SubdomainAssetsRepository(ProgramAccessMixin):
                 program = db.query(Program).filter(Program.name == subdomain_data.get('program_name')).first()
                 if not program:
                     raise ValueError(f"Program '{subdomain_data.get('program_name')}' not found")
-                
-                # Scope check for the subdomain hostname
-                hostname = subdomain_data.get('name')
-                program_name = subdomain_data.get('program_name')
-                if not hostname:
+
+                hn = normalize_hostname(subdomain_data.get('name'))
+                if not hn:
                     raise ValueError("'name' (subdomain) is required")
+                subdomain_data['name'] = hn
+                if subdomain_data.get('apex_domain'):
+                    subdomain_data['apex_domain'] = normalize_hostname(str(subdomain_data['apex_domain']))
+                if subdomain_data.get('cname_record'):
+                    subdomain_data['cname_record'] = normalize_hostname(str(subdomain_data['cname_record']))
+
+                # Scope check for the subdomain hostname
+                hostname = hn
+                program_name = subdomain_data.get('program_name')
                 if not await ProgramRepository.is_domain_in_scope(hostname, program_name):
                     logger.info(f"Subdomain '{hostname}' is out of scope for program '{program_name}'")
                     return "", "out_of_scope", None, None

--- a/src/api/app/repository/typosquat_findings_repo.py
+++ b/src/api/app/repository/typosquat_findings_repo.py
@@ -8,7 +8,7 @@ from models.base import utcnow
 import uuid
 import json
 from utils import normalize_url_for_storage
-from utils.domain_utils import extract_apex_domain
+from utils.domain_utils import extract_apex_domain, normalize_hostname
 import tldextract
 import asyncio
 from services.kubernetes import KubernetesService
@@ -488,7 +488,10 @@ class TyposquatFindingsRepository(ProgramAccessMixin):
         async with get_db_session() as db:
             try:
                 program = resolve_program_from_payload(db, typosquat_data)
-                
+
+                if typosquat_data.get('typo_domain'):
+                    typosquat_data['typo_domain'] = normalize_hostname(str(typosquat_data['typo_domain']))
+
                 # Check if typosquat domain already exists (filter by both domain and program for accuracy)
                 existing = db.query(TyposquatDomain).filter(
                     TyposquatDomain.typo_domain == typosquat_data.get('typo_domain'),

--- a/src/api/app/repository/url_assets_repo.py
+++ b/src/api/app/repository/url_assets_repo.py
@@ -13,6 +13,8 @@ from models.postgres import (
 from db import get_db_session
 from utils.query_filters import ProgramAccessMixin
 from utils import get_root_url
+from utils.domain_utils import normalize_hostname
+from utils.url_utils import lower_url_host
 from repository.program_repo import ProgramRepository
 
 logger = logging.getLogger(__name__)
@@ -267,7 +269,12 @@ class UrlAssetsRepository(ProgramAccessMixin):
         """
         # Get current links for this URL
         current_links = {source.extracted_link.link_url for source in url_obj.extracted_link_sources}
-        new_links_set = {link.strip() for link in new_links if link and link.strip()}
+        new_links_set = set()
+        for link in new_links:
+            if link and link.strip():
+                ln = lower_url_host(link.strip())
+                if ln:
+                    new_links_set.add(ln)
 
         # Filter out links that are in scope (we only want external links)
         filtered_links = set()
@@ -481,6 +488,13 @@ class UrlAssetsRepository(ProgramAccessMixin):
         async with get_db_session() as db:
             try:
                 logger.debug(f"create_or_update_url called with URL data: {url_data}")
+                # Hostname / URL host stored lowercase; preserve path/query casing
+                if url_data.get('url'):
+                    url_data['url'] = lower_url_host(str(url_data['url'])) or url_data['url']
+                if url_data.get('hostname'):
+                    url_data['hostname'] = normalize_hostname(str(url_data['hostname']))
+                if url_data.get('final_url'):
+                    url_data['final_url'] = lower_url_host(str(url_data['final_url']))
                 # Find program by name
                 program = db.query(Program).filter(Program.name == url_data.get('program_name')).first()
                 if not program:
@@ -631,7 +645,7 @@ class UrlAssetsRepository(ProgramAccessMixin):
                     if 'extracted_links' in url_data and isinstance(url_data['extracted_links'], list):
                         for link_url in url_data['extracted_links']:
                             if link_url and link_url.strip():
-                                link_url = link_url.strip()
+                                link_url = lower_url_host(link_url.strip()) or link_url.strip()
 
                                 # Check if the link is in scope (skip if it is)
                                 try:
@@ -702,7 +716,7 @@ class UrlAssetsRepository(ProgramAccessMixin):
                 filtered_links = []
                 for link_url in links:
                     if link_url and link_url.strip():
-                        link_url = link_url.strip()
+                        link_url = lower_url_host(link_url.strip()) or link_url.strip()
                         try:
                             parsed = urlparse(link_url)
                             hostname = parsed.hostname

--- a/src/api/app/repository/wpscan_findings_repo.py
+++ b/src/api/app/repository/wpscan_findings_repo.py
@@ -11,6 +11,8 @@ from db import get_db_session
 # Direct import to avoid circular import
 from utils.query_filters import QueryFilterUtils, ProgramAccessMixin
 from utils.program_resolve import resolve_program_from_payload
+from utils.domain_utils import normalize_hostname
+from utils.url_utils import lower_url_host
 from services.event_publisher import publisher
 
 logger = logging.getLogger(__name__)
@@ -25,7 +27,14 @@ class WPScanFindingsRepository(ProgramAccessMixin):
         async with get_db_session() as db:
             try:
                 program = resolve_program_from_payload(db, finding_data)
-                
+
+                if finding_data.get("url"):
+                    finding_data["url"] = lower_url_host(str(finding_data["url"])) or finding_data["url"]
+                if finding_data.get("hostname"):
+                    finding_data["hostname"] = normalize_hostname(str(finding_data["hostname"]))
+                if finding_data.get("scheme") and isinstance(finding_data["scheme"], str):
+                    finding_data["scheme"] = finding_data["scheme"].lower()
+
                 # Check if finding already exists based on unique constraint fields
                 existing = db.query(WPScanFinding).filter(
                     and_(

--- a/src/api/app/utils/domain_utils.py
+++ b/src/api/app/utils/domain_utils.py
@@ -3,11 +3,34 @@ Utility functions for domain processing and apex domain extraction.
 """
 import tldextract
 import logging
-from typing import Dict, Any, List
+from typing import Dict, Any, List, Optional
 from datetime import datetime
 import re
 
 logger = logging.getLogger(__name__)
+
+
+def normalize_hostname(value: Optional[str]) -> Optional[str]:
+    """
+    Normalize a hostname or FQDN for storage (strip, drop trailing dots, lowercase).
+
+    Does not strip ``www`` (unlike ``normalize_domain_for_comparison``).
+
+    Examples:
+        >>> normalize_hostname("  Foo.EXAMPLE.COM. ")
+        'foo.example.com'
+        >>> normalize_hostname(None)
+        None
+        >>> normalize_hostname("")
+        ''
+    """
+    if value is None:
+        return None
+    s = str(value).strip()
+    if not s:
+        return s
+    return s.rstrip(".").lower()
+
 
 def normalize_domain_for_comparison(domain: str) -> str:
     """

--- a/src/api/app/utils/url_utils.py
+++ b/src/api/app/utils/url_utils.py
@@ -1,9 +1,43 @@
+from __future__ import annotations
+
 from fastapi import Request
-from urllib.parse import urlparse
-from typing import List
+from urllib.parse import urlparse, urlsplit, urlunsplit
+from typing import List, Optional
 import logging
 
+from .domain_utils import is_valid_domain
+
 logger = logging.getLogger(__name__)
+
+
+def lower_url_host(url: Optional[str]) -> Optional[str]:
+    """
+    Lowercase only the scheme and netloc (host[:port], userinfo) of a URL;
+    preserve path, query string, and fragment casing.
+
+    Handles absolute URLs with a scheme and scheme-relative URLs (``//host/...``).
+    Leaves relative paths (no netloc) unchanged except for stripping.
+
+    Examples:
+        >>> lower_url_host("HTTPS://WWW.Example.COM:8443/Path?Q=1#Frag")
+        'https://www.example.com:8443/Path?Q=1#Frag'
+        >>> lower_url_host("//Foo.com/bar")
+        '//foo.com/bar'
+        >>> lower_url_host(None)
+        None
+        >>> lower_url_host("")
+        ''
+    """
+    if url is None:
+        return None
+    s = str(url).strip()
+    if not s:
+        return s
+    parts = urlsplit(s)
+    scheme = parts.scheme.lower() if parts.scheme else ""
+    netloc = parts.netloc.lower() if parts.netloc else ""
+    return urlunsplit((scheme, netloc, parts.path, parts.query, parts.fragment))
+
 
 def create_status_url(request: Request, resource_type: str, resource_id: str) -> str:
     """Create a status URL for a resource"""

--- a/src/api/tests/test_bulk_sql_urls.py
+++ b/src/api/tests/test_bulk_sql_urls.py
@@ -25,3 +25,12 @@ def test_urls_require_full_orm_extracted_links():
     from repository.bulk_sql.urls import urls_require_full_orm
 
     assert urls_require_full_orm([{"url": "x", "extracted_links": ["http://ext"]}]) is True
+
+
+def test_lower_url_host_merges_duplicate_batch_keys_case_only():
+    """Bulk URL dedupe keys use lower_url_host — same DNS host must collide."""
+    from utils.url_utils import lower_url_host
+
+    u1 = lower_url_host("https://Aa.Com/p")
+    u2 = lower_url_host("HTTPS://aa.COM/p")
+    assert u1 == u2 == "https://aa.com/p"

--- a/src/api/tests/test_hostname_normalize_helpers.py
+++ b/src/api/tests/test_hostname_normalize_helpers.py
@@ -1,0 +1,40 @@
+"""Unit tests for hostname / URL-host normalization helpers."""
+
+from app.utils.domain_utils import normalize_hostname
+from app.utils.url_utils import lower_url_host
+
+
+class TestNormalizeHostname:
+    def test_lowercase_trim_trailing_dot(self):
+        assert normalize_hostname("  Foo.EXAMPLE.COM. ") == "foo.example.com"
+
+    def test_none(self):
+        assert normalize_hostname(None) is None
+
+    def test_empty_after_strip(self):
+        assert normalize_hostname("   ") == ""
+
+
+class TestLowerUrlHost:
+    def test_full_url_preserves_path_query_fragment(self):
+        assert (
+            lower_url_host("HTTPS://WWW.Example.COM:8443/Path?Q=1#Frag")
+            == "https://www.example.com:8443/Path?Q=1#Frag"
+        )
+
+    def test_scheme_relative(self):
+        assert lower_url_host("//Foo.com/bar") == "//foo.com/bar"
+
+    def test_ipv6_bracket_host(self):
+        assert (
+            lower_url_host("HTTP://[FEDC:BA98::7654]/p")
+            == "http://[fedc:ba98::7654]/p"
+        )
+
+    def test_plain_path_unchanged(self):
+        """No netloc → host portion not modified (consistent with ingestion using absolute URLs)."""
+        assert lower_url_host("WWW.Example.COM") == "WWW.Example.COM"
+
+    def test_none_and_empty(self):
+        assert lower_url_host(None) is None
+        assert lower_url_host("") == ""

--- a/src/api/tests/test_migration_0013_lowercase_optional.py
+++ b/src/api/tests/test_migration_0013_lowercase_optional.py
@@ -1,0 +1,76 @@
+"""
+Optional Postgres check: migration_0013_lower_url_host(plpgsql) vs Python lower_url_host().
+
+Requires DATABASE_URL pointing at Postgres and RECON_PG_MIGRATION_SMOKE=1.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine, text
+
+from app.utils.url_utils import lower_url_host
+
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("DATABASE_URL"),
+    reason="DATABASE_URL must point at Postgres for migration function smoke tests",
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+_MIGRATION_FILE = REPO_ROOT / "src" / "migrations" / "alembic" / "versions" / "0013_lowercase_hostnames.py"
+
+
+def _load_migration_module():
+    spec = importlib.util.spec_from_file_location("migration_0013_lowercase_hostnames", _MIGRATION_FILE)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Cannot load {_MIGRATION_FILE}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.mark.skipif(
+    os.environ.get("RECON_PG_MIGRATION_SMOKE", "").lower() not in {"1", "true", "yes"},
+    reason="Set RECON_PG_MIGRATION_SMOKE=1 to run Postgres migration parity checks",
+)
+def test_migration_lower_url_host_matches_python_helpers():
+    migration = _load_migration_module()
+    engine = create_engine(os.environ["DATABASE_URL"], future=True)
+    samples = [
+        "HTTPS://WWW.Example.COM:8443/Path?Q=1#Frag",
+        "//Foo.com/bar",
+        "HTTP://[FEDC:BA98::7654]/p",
+    ]
+    with engine.begin() as conn:
+        conn.execute(text(migration._CREATE_FN.strip()))
+        try:
+            for s in samples:
+                py_val = lower_url_host(s)
+                row = conn.execute(
+                    text("SELECT migration_0013_lower_url_host(:x) AS v"),
+                    {"x": s},
+                ).one()
+                assert row.v == py_val, (s, row.v, py_val)
+        finally:
+            conn.execute(text(migration._DROP_FN))
+
+
+@pytest.mark.skipif(
+    os.environ.get("RECON_PG_MIGRATION_SMOKE", "").lower() not in {"1", "true", "yes"},
+    reason="Set RECON_PG_MIGRATION_SMOKE=1 to run Postgres migration parity checks",
+)
+def test_migration_fn_idempotent_repeat_apply():
+    """CREATE OR REPLACE and DROP behave when run twice (mirrors alembic re-run)."""
+    migration = _load_migration_module()
+    engine = create_engine(os.environ["DATABASE_URL"], future=True)
+    with engine.begin() as conn:
+        conn.execute(text(migration._CREATE_FN.strip()))
+        conn.execute(text(migration._CREATE_FN.strip()))
+        conn.execute(text(migration._DROP_FN))
+        conn.execute(text(migration._DROP_FN))

--- a/src/migrations/alembic/versions/0013_lowercase_hostnames.py
+++ b/src/migrations/alembic/versions/0013_lowercase_hostnames.py
@@ -1,0 +1,637 @@
+"""Lowercase hostnames/FQDNs and URL hosts; merge case-only duplicates.
+
+Revision ID: v012_lowercase_hostnames
+Revises: v011_waf_settings_extend
+
+Running twice against an already-clean database is effectively a no-op.
+Downgrade is no-op (original casing cannot be restored).
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "v012_lowercase_hostnames"
+down_revision: Union[str, Sequence[str], None] = "v011_waf_settings_extend"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_CREATE_FN = """
+CREATE OR REPLACE FUNCTION migration_0013_lower_url_host(u text)
+RETURNS text
+LANGUAGE plpgsql
+IMMUTABLE
+AS $$
+DECLARE
+  m text[];
+  prefix_len int;
+BEGIN
+  IF u IS NULL THEN
+    RETURN NULL;
+  END IF;
+  IF u = '' THEN
+    RETURN u;
+  END IF;
+  m := regexp_match(u, '^([a-zA-Z][a-zA-Z0-9+.-]*://)([^/?#]*)');
+  IF m IS NOT NULL THEN
+    prefix_len := length(m[1]) + length(m[2]);
+    RETURN m[1] || lower(m[2]) || substr(u, prefix_len + 1);
+  END IF;
+  m := regexp_match(u, '^(//)([^/?#]*)');
+  IF m IS NOT NULL THEN
+    prefix_len := length(m[1]) + length(m[2]);
+    RETURN m[1] || lower(m[2]) || substr(u, prefix_len + 1);
+  END IF;
+  RETURN u;
+END;
+$$;
+"""
+
+_DROP_FN = "DROP FUNCTION IF EXISTS migration_0013_lower_url_host(text);"
+
+
+def upgrade() -> None:
+    op.execute(sa.text(_CREATE_FN))
+
+    op.execute(
+        sa.text(
+            """
+WITH keepers AS (
+  SELECT DISTINCT ON (program_id, lower(name))
+    id AS keep_id,
+    program_id,
+    lower(name) AS lk
+  FROM apex_domains
+  ORDER BY program_id, lower(name), created_at ASC, id ASC
+),
+dups AS (
+  SELECT ad.id AS old_id,
+    k.keep_id
+  FROM apex_domains ad
+  JOIN keepers k
+    ON k.program_id = ad.program_id AND k.lk = lower(ad.name)
+  WHERE ad.id <> k.keep_id
+)
+UPDATE subdomains s
+SET apex_domain_id = d.keep_id
+FROM dups d
+WHERE s.apex_domain_id = d.old_id
+  AND s.apex_domain_id <> d.keep_id;
+
+WITH keepers AS (
+  SELECT DISTINCT ON (program_id, lower(name))
+    id AS keep_id,
+    program_id,
+    lower(name) AS lk
+  FROM apex_domains
+  ORDER BY program_id, lower(name), created_at ASC, id ASC
+),
+dups AS (
+  SELECT ad.id AS old_id
+  FROM apex_domains ad
+  JOIN keepers k
+    ON k.program_id = ad.program_id AND k.lk = lower(ad.name)
+  WHERE ad.id <> k.keep_id
+)
+DELETE FROM apex_domains WHERE id IN (SELECT old_id FROM dups);
+
+UPDATE apex_domains SET name = lower(name) WHERE name <> lower(name);
+"""
+        )
+    )
+
+    op.execute(
+        sa.text(
+            """
+WITH keepers AS (
+  SELECT DISTINCT ON (program_id, lower(name))
+    id AS keep_id,
+    program_id,
+    lower(name) AS lk
+  FROM subdomains
+  ORDER BY program_id, lower(name), created_at ASC, id ASC
+),
+dups AS (
+  SELECT s.id AS old_id,
+    k.keep_id
+  FROM subdomains s
+  JOIN keepers k
+    ON k.program_id = s.program_id AND k.lk = lower(s.name)
+  WHERE s.id <> k.keep_id
+)
+INSERT INTO subdomain_ips (id, subdomain_id, ip_id, created_at)
+SELECT gen_random_uuid(), d.keep_id, si.ip_id, si.created_at
+FROM subdomain_ips si
+JOIN dups d ON si.subdomain_id = d.old_id
+ON CONFLICT ON CONSTRAINT subdomain_ips_subdomain_id_ip_id_key DO NOTHING;
+
+WITH keepers AS (
+  SELECT DISTINCT ON (program_id, lower(name))
+    id AS keep_id,
+    program_id,
+    lower(name) AS lk
+  FROM subdomains
+  ORDER BY program_id, lower(name), created_at ASC, id ASC
+),
+dups AS (
+  SELECT s.id AS old_id
+  FROM subdomains s
+  JOIN keepers k
+    ON k.program_id = s.program_id AND k.lk = lower(s.name)
+  WHERE s.id <> k.keep_id
+)
+DELETE FROM subdomain_ips WHERE subdomain_id IN (SELECT old_id FROM dups);
+
+WITH keepers AS (
+  SELECT DISTINCT ON (program_id, lower(name))
+    id AS keep_id,
+    program_id,
+    lower(name) AS lk
+  FROM subdomains
+  ORDER BY program_id, lower(name), created_at ASC, id ASC
+),
+dups AS (
+  SELECT s.id AS old_id,
+    k.keep_id
+  FROM subdomains s
+  JOIN keepers k
+    ON k.program_id = s.program_id AND k.lk = lower(s.name)
+  WHERE s.id <> k.keep_id
+)
+UPDATE urls u
+SET subdomain_id = d.keep_id
+FROM dups d
+WHERE u.subdomain_id = d.old_id
+  AND u.subdomain_id IS NOT NULL;
+
+WITH keepers AS (
+  SELECT DISTINCT ON (program_id, lower(name))
+    id AS keep_id,
+    program_id,
+    lower(name) AS lk
+  FROM subdomains
+  ORDER BY program_id, lower(name), created_at ASC, id ASC
+),
+dups AS (
+  SELECT s.id AS old_id
+  FROM subdomains s
+  JOIN keepers k
+    ON k.program_id = s.program_id AND k.lk = lower(s.name)
+  WHERE s.id <> k.keep_id
+)
+DELETE FROM subdomains WHERE id IN (SELECT old_id FROM dups);
+
+UPDATE subdomains
+SET name = lower(name),
+    cname_record = CASE
+      WHEN cname_record IS NOT NULL THEN lower(cname_record)
+      ELSE cname_record
+    END
+WHERE name <> lower(name)
+   OR (cname_record IS NOT NULL AND cname_record <> lower(cname_record));
+"""
+        )
+    )
+
+    op.execute(
+        sa.text(
+            """
+WITH url_keepers AS (
+  SELECT DISTINCT ON (program_id, migration_0013_lower_url_host(url))
+    id AS keep_id,
+    program_id,
+    migration_0013_lower_url_host(url) AS nu
+  FROM urls
+  ORDER BY program_id, migration_0013_lower_url_host(url), created_at ASC, id ASC
+),
+url_dups AS (
+  SELECT u.id AS old_id,
+    k.keep_id
+  FROM urls u
+  JOIN url_keepers k
+    ON k.program_id = u.program_id AND k.nu = migration_0013_lower_url_host(u.url)
+  WHERE u.id <> k.keep_id
+)
+INSERT INTO url_services (id, url_id, service_id, created_at)
+SELECT gen_random_uuid(), d.keep_id, us.service_id, us.created_at
+FROM url_services us
+JOIN url_dups d ON us.url_id = d.old_id
+ON CONFLICT ON CONSTRAINT url_services_url_id_service_id_key DO NOTHING;
+
+WITH url_keepers AS (
+  SELECT DISTINCT ON (program_id, migration_0013_lower_url_host(url))
+    id AS keep_id,
+    program_id,
+    migration_0013_lower_url_host(url) AS nu
+  FROM urls
+  ORDER BY program_id, migration_0013_lower_url_host(url), created_at ASC, id ASC
+),
+url_dups AS (
+  SELECT u.id AS old_id,
+    k.keep_id
+  FROM urls u
+  JOIN url_keepers k
+    ON k.program_id = u.program_id AND k.nu = migration_0013_lower_url_host(u.url)
+  WHERE u.id <> k.keep_id
+)
+INSERT INTO url_technologies (id, technology_id, url_id, created_at)
+SELECT gen_random_uuid(), ut.technology_id, d.keep_id, ut.created_at
+FROM url_technologies ut
+JOIN url_dups d ON ut.url_id = d.old_id
+ON CONFLICT (technology_id, url_id) DO NOTHING;
+
+WITH url_keepers AS (
+  SELECT DISTINCT ON (program_id, migration_0013_lower_url_host(url))
+    id AS keep_id,
+    program_id,
+    migration_0013_lower_url_host(url) AS nu
+  FROM urls
+  ORDER BY program_id, migration_0013_lower_url_host(url), created_at ASC, id ASC
+),
+url_dups AS (
+  SELECT u.id AS old_id,
+    k.keep_id
+  FROM urls u
+  JOIN url_keepers k
+    ON k.program_id = u.program_id AND k.nu = migration_0013_lower_url_host(u.url)
+  WHERE u.id <> k.keep_id
+)
+DELETE FROM extracted_link_sources els USING url_dups d
+WHERE els.source_url_id = d.old_id
+  AND EXISTS (
+    SELECT 1 FROM extracted_link_sources x
+    WHERE x.extracted_link_id = els.extracted_link_id
+      AND x.source_url_id = d.keep_id);
+
+WITH url_keepers AS (
+  SELECT DISTINCT ON (program_id, migration_0013_lower_url_host(url))
+    id AS keep_id,
+    program_id,
+    migration_0013_lower_url_host(url) AS nu
+  FROM urls
+  ORDER BY program_id, migration_0013_lower_url_host(url), created_at ASC, id ASC
+),
+url_dups AS (
+  SELECT u.id AS old_id,
+    k.keep_id
+  FROM urls u
+  JOIN url_keepers k
+    ON k.program_id = u.program_id AND k.nu = migration_0013_lower_url_host(u.url)
+  WHERE u.id <> k.keep_id
+)
+UPDATE extracted_link_sources els
+SET source_url_id = d.keep_id
+FROM url_dups d
+WHERE els.source_url_id = d.old_id;
+
+WITH url_keepers AS (
+  SELECT DISTINCT ON (program_id, migration_0013_lower_url_host(url))
+    id AS keep_id,
+    program_id,
+    migration_0013_lower_url_host(url) AS nu
+  FROM urls
+  ORDER BY program_id, migration_0013_lower_url_host(url), created_at ASC, id ASC
+),
+url_dups AS (
+  SELECT u.id AS old_id,
+    k.keep_id
+  FROM urls u
+  JOIN url_keepers k
+    ON k.program_id = u.program_id AND k.nu = migration_0013_lower_url_host(u.url)
+  WHERE u.id <> k.keep_id
+)
+UPDATE screenshots sc
+SET url_id = d.keep_id
+FROM url_dups d
+WHERE sc.url_id = d.old_id;
+
+WITH url_keepers AS (
+  SELECT DISTINCT ON (program_id, migration_0013_lower_url_host(url))
+    id AS keep_id,
+    program_id,
+    migration_0013_lower_url_host(url) AS nu
+  FROM urls
+  ORDER BY program_id, migration_0013_lower_url_host(url), created_at ASC, id ASC
+),
+url_dups AS (
+  SELECT u.id AS old_id
+  FROM urls u
+  JOIN url_keepers k
+    ON k.program_id = u.program_id AND k.nu = migration_0013_lower_url_host(u.url)
+  WHERE u.id <> k.keep_id
+)
+DELETE FROM url_services WHERE url_id IN (SELECT old_id FROM url_dups);
+
+WITH url_keepers AS (
+  SELECT DISTINCT ON (program_id, migration_0013_lower_url_host(url))
+    id AS keep_id,
+    program_id,
+    migration_0013_lower_url_host(url) AS nu
+  FROM urls
+  ORDER BY program_id, migration_0013_lower_url_host(url), created_at ASC, id ASC
+),
+url_dups AS (
+  SELECT u.id AS old_id
+  FROM urls u
+  JOIN url_keepers k
+    ON k.program_id = u.program_id AND k.nu = migration_0013_lower_url_host(u.url)
+  WHERE u.id <> k.keep_id
+)
+DELETE FROM url_technologies WHERE url_id IN (SELECT old_id FROM url_dups);
+
+WITH url_keepers AS (
+  SELECT DISTINCT ON (program_id, migration_0013_lower_url_host(url))
+    id AS keep_id,
+    program_id,
+    migration_0013_lower_url_host(url) AS nu
+  FROM urls
+  ORDER BY program_id, migration_0013_lower_url_host(url), created_at ASC, id ASC
+),
+url_dups AS (
+  SELECT u.id AS old_id
+  FROM urls u
+  JOIN url_keepers k
+    ON k.program_id = u.program_id AND k.nu = migration_0013_lower_url_host(u.url)
+  WHERE u.id <> k.keep_id
+)
+DELETE FROM urls WHERE id IN (SELECT old_id FROM url_dups);
+
+UPDATE urls
+SET url = migration_0013_lower_url_host(url),
+    hostname = lower(hostname),
+    final_url = CASE
+      WHEN final_url IS NOT NULL THEN migration_0013_lower_url_host(final_url)
+      ELSE final_url END
+WHERE url <> migration_0013_lower_url_host(url)
+   OR hostname <> lower(hostname)
+   OR (final_url IS NOT NULL AND final_url <> migration_0013_lower_url_host(final_url));
+"""
+        )
+    )
+
+    op.execute(
+        sa.text(
+            """
+WITH lk_keepers AS (
+  SELECT DISTINCT ON (program_id, migration_0013_lower_url_host(link_url))
+    id AS keep_id,
+    program_id,
+    migration_0013_lower_url_host(link_url) AS nu
+  FROM extracted_links
+  ORDER BY program_id, migration_0013_lower_url_host(link_url), created_at ASC, id ASC
+),
+lk_dups AS (
+  SELECT e.id AS old_id,
+    k.keep_id
+  FROM extracted_links e
+  JOIN lk_keepers k
+    ON k.program_id = e.program_id AND k.nu = migration_0013_lower_url_host(e.link_url)
+  WHERE e.id <> k.keep_id
+)
+DELETE FROM extracted_link_sources els USING lk_dups d
+WHERE els.extracted_link_id = d.old_id
+  AND EXISTS (
+    SELECT 1 FROM extracted_link_sources x
+    WHERE x.source_url_id = els.source_url_id
+      AND x.extracted_link_id = d.keep_id);
+
+WITH lk_keepers AS (
+  SELECT DISTINCT ON (program_id, migration_0013_lower_url_host(link_url))
+    id AS keep_id,
+    program_id,
+    migration_0013_lower_url_host(link_url) AS nu
+  FROM extracted_links
+  ORDER BY program_id, migration_0013_lower_url_host(link_url), created_at ASC, id ASC
+),
+lk_dups AS (
+  SELECT e.id AS old_id,
+    k.keep_id
+  FROM extracted_links e
+  JOIN lk_keepers k
+    ON k.program_id = e.program_id AND k.nu = migration_0013_lower_url_host(e.link_url)
+  WHERE e.id <> k.keep_id
+)
+UPDATE extracted_link_sources els
+SET extracted_link_id = d.keep_id
+FROM lk_dups d
+WHERE els.extracted_link_id = d.old_id;
+
+WITH lk_keepers AS (
+  SELECT DISTINCT ON (program_id, migration_0013_lower_url_host(link_url))
+    id AS keep_id,
+    program_id,
+    migration_0013_lower_url_host(link_url) AS nu
+  FROM extracted_links
+  ORDER BY program_id, migration_0013_lower_url_host(link_url), created_at ASC, id ASC
+),
+lk_dups AS (
+  SELECT e.id AS old_id
+  FROM extracted_links e
+  JOIN lk_keepers k
+    ON k.program_id = e.program_id AND k.nu = migration_0013_lower_url_host(e.link_url)
+  WHERE e.id <> k.keep_id
+)
+DELETE FROM extracted_links WHERE id IN (SELECT old_id FROM lk_dups);
+
+UPDATE extracted_links
+SET link_url = migration_0013_lower_url_host(link_url)
+WHERE link_url <> migration_0013_lower_url_host(link_url);
+"""
+        )
+    )
+
+    op.execute(
+        sa.text(
+            """
+UPDATE ips SET ptr_record = lower(ptr_record)
+WHERE ptr_record IS NOT NULL AND ptr_record <> lower(ptr_record);
+
+WITH typ_keep AS (
+  SELECT DISTINCT ON (lower(typo_domain))
+    id AS keep_id,
+    lower(typo_domain) AS lk
+  FROM typosquat_domains
+  ORDER BY lower(typo_domain), detected_at ASC, id ASC
+),
+typ_dups AS (
+  SELECT t.id AS old_id,
+    k.keep_id
+  FROM typosquat_domains t
+  JOIN typ_keep k ON k.lk = lower(t.typo_domain)
+  WHERE t.id <> k.keep_id
+)
+UPDATE typosquat_urls tu SET typosquat_domain_id = d.keep_id FROM typ_dups d
+WHERE tu.typosquat_domain_id = d.old_id;
+
+WITH typ_keep AS (
+  SELECT DISTINCT ON (lower(typo_domain))
+    id AS keep_id,
+    lower(typo_domain) AS lk
+  FROM typosquat_domains
+  ORDER BY lower(typo_domain), detected_at ASC, id ASC
+),
+typ_dups AS (
+  SELECT t.id AS old_id
+  FROM typosquat_domains t
+  JOIN typ_keep k ON k.lk = lower(t.typo_domain)
+  WHERE t.id <> k.keep_id
+)
+DELETE FROM typosquat_domains WHERE id IN (SELECT old_id FROM typ_dups);
+
+UPDATE typosquat_domains SET typo_domain = lower(typo_domain)
+WHERE typo_domain <> lower(typo_domain);
+
+WITH tu_keep AS (
+  SELECT DISTINCT ON (migration_0013_lower_url_host(url))
+    id AS keep_id,
+    migration_0013_lower_url_host(url) AS nu
+  FROM typosquat_urls
+  ORDER BY migration_0013_lower_url_host(url), created_at ASC, id ASC
+),
+tu_dups AS (
+  SELECT t.id AS old_id,
+    k.keep_id
+  FROM typosquat_urls t
+  JOIN tu_keep k ON k.nu = migration_0013_lower_url_host(t.url)
+  WHERE t.id <> k.keep_id
+)
+UPDATE typosquat_screenshots ts
+SET url_id = d.keep_id
+FROM tu_dups d
+WHERE ts.url_id = d.old_id;
+
+WITH tu_keep AS (
+  SELECT DISTINCT ON (migration_0013_lower_url_host(url))
+    id AS keep_id,
+    migration_0013_lower_url_host(url) AS nu
+  FROM typosquat_urls
+  ORDER BY migration_0013_lower_url_host(url), created_at ASC, id ASC
+),
+tu_dups AS (
+  SELECT t.id AS old_id
+  FROM typosquat_urls t
+  JOIN tu_keep k ON k.nu = migration_0013_lower_url_host(t.url)
+  WHERE t.id <> k.keep_id
+)
+DELETE FROM typosquat_urls WHERE id IN (SELECT old_id FROM tu_dups);
+
+UPDATE typosquat_urls SET
+  url = migration_0013_lower_url_host(url),
+  hostname = lower(hostname),
+  scheme = CASE WHEN scheme IS NOT NULL THEN lower(scheme) ELSE scheme END,
+  final_url = CASE
+    WHEN final_url IS NOT NULL THEN migration_0013_lower_url_host(final_url)
+    ELSE final_url END,
+  favicon_url = CASE
+    WHEN favicon_url IS NOT NULL THEN migration_0013_lower_url_host(favicon_url)
+    ELSE favicon_url END
+WHERE url <> migration_0013_lower_url_host(url)
+   OR hostname <> lower(hostname)
+   OR (scheme IS NOT NULL AND scheme <> lower(scheme))
+   OR (final_url IS NOT NULL AND final_url <> migration_0013_lower_url_host(final_url))
+   OR (favicon_url IS NOT NULL AND favicon_url <> migration_0013_lower_url_host(favicon_url));
+"""
+        )
+    )
+
+    op.execute(
+        sa.text(
+            """
+UPDATE nuclei_findings
+SET url = migration_0013_lower_url_host(url),
+    template_url = CASE
+      WHEN template_url IS NOT NULL
+       AND template_url LIKE 'http%'
+      THEN migration_0013_lower_url_host(template_url)
+      ELSE template_url END,
+    hostname = CASE WHEN hostname IS NOT NULL THEN lower(hostname) ELSE hostname END,
+    scheme = CASE WHEN scheme IS NOT NULL THEN lower(scheme) ELSE scheme END;
+
+DELETE FROM nuclei_findings n
+WHERE EXISTS (
+  SELECT 1
+  FROM nuclei_findings k
+  WHERE k.id <> n.id
+    AND k.program_id = n.program_id
+    AND k.url IS NOT DISTINCT FROM n.url
+    AND k.template_id IS NOT DISTINCT FROM n.template_id
+    AND k.matcher_name IS NOT DISTINCT FROM n.matcher_name
+    AND k.matched_at IS NOT DISTINCT FROM n.matched_at
+    AND (
+      k.created_at < n.created_at
+      OR (k.created_at = n.created_at AND k.id < n.id)
+    )
+);
+"""
+        )
+    )
+
+    op.execute(
+        sa.text(
+            """
+UPDATE wpscan_findings SET
+    url = migration_0013_lower_url_host(url),
+    hostname = CASE WHEN hostname IS NOT NULL THEN lower(hostname) ELSE hostname END,
+    scheme = CASE WHEN scheme IS NOT NULL THEN lower(scheme) ELSE scheme END
+WHERE url <> migration_0013_lower_url_host(url)
+   OR (hostname IS NOT NULL AND hostname <> lower(hostname))
+   OR (scheme IS NOT NULL AND scheme <> lower(scheme));
+"""
+        )
+    )
+
+    op.execute(
+        sa.text(
+            """
+WITH bl_keepers AS (
+  SELECT DISTINCT ON (program_id, migration_0013_lower_url_host(url))
+    id AS keep_id,
+    program_id,
+    migration_0013_lower_url_host(url) AS nu
+  FROM broken_links
+  WHERE url IS NOT NULL
+  ORDER BY program_id, migration_0013_lower_url_host(url), created_at ASC, id ASC
+),
+bl_dups AS (
+  SELECT b.id AS old_id
+  FROM broken_links b
+  JOIN bl_keepers k
+    ON k.program_id = b.program_id AND k.nu = migration_0013_lower_url_host(b.url)
+  WHERE b.url IS NOT NULL
+    AND b.id <> k.keep_id
+)
+DELETE FROM broken_links bl
+WHERE bl.id IN (SELECT old_id FROM bl_dups);
+
+UPDATE broken_links SET
+    url = CASE WHEN url IS NOT NULL THEN migration_0013_lower_url_host(url) ELSE url END,
+    domain = CASE WHEN domain IS NOT NULL THEN lower(domain) ELSE domain END
+WHERE url IS DISTINCT FROM CASE WHEN url IS NOT NULL THEN migration_0013_lower_url_host(url) ELSE url END
+   OR domain IS DISTINCT FROM CASE WHEN domain IS NOT NULL THEN lower(domain) ELSE domain END;
+"""
+        )
+    )
+
+    op.execute(
+        sa.text(
+            """
+UPDATE droopescan_findings SET
+    url = migration_0013_lower_url_host(url),
+    host = CASE WHEN host IS NOT NULL THEN lower(host) ELSE host END,
+    hostname = CASE WHEN hostname IS NOT NULL THEN lower(hostname) ELSE hostname END,
+    scheme = CASE WHEN scheme IS NOT NULL THEN lower(scheme) ELSE scheme END
+WHERE url <> migration_0013_lower_url_host(url)
+   OR (host IS NOT NULL AND host <> lower(host))
+   OR (hostname IS NOT NULL AND hostname <> lower(hostname))
+   OR (scheme IS NOT NULL AND scheme <> lower(scheme));
+"""
+        )
+    )
+
+    op.execute(sa.text(_DROP_FN))
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
Add normalize_hostname() and lower_url_host() and apply them on bulk_sql upserts and ORM paths for subdomain, apex, URL, IP (PTR-related fields), and findings (nuclei, wpscan, broken links, typosquat). Certificate subject CN/SAN are unchanged.

Alembic v012 merges case-only duplicates (apex_domains, subdomains, urls, extracted_links, typosquat, broken_links, nuclei) and lowercases ips.ptr plus droopescan findings. Drops the temporary PG URL helper after the migration run.

Tests cover helpers and bulk URL dedupe keys; optional Postgres parity checks when DATABASE_URL and RECON_PG_MIGRATION_SMOKE=1 are set. kubernetes/base/postgresql/schema.sql refreshed from pg_dump baseline.