### PR TITLE
feat(crawl_website): fan out httpx across nodes after Katana discover

### DIFF
--- a/src/api/app/recon_task_builtin_defaults.yaml
+++ b/src/api/app/recon_task_builtin_defaults.yaml
@@ -137,6 +137,8 @@ crawl_website:
   timeout: 1800
   chunk_size: 1
   depth: 5
+  httpx_urls_per_job: 25
+  katana_timeout: 900
   input_types: [url]
   output_types: [url]
 fuzz_website:

--- a/src/frontend/src/components/workflow/constants.js
+++ b/src/frontend/src/components/workflow/constants.js
@@ -242,8 +242,10 @@ export const TASK_TYPES = {
     category: 'Discovery',
     icon: '🕷️',
     params: {
-      timeout: { type: 'number', default: 1800, description: 'Optional timeout override in seconds (uses system default if not specified)' },
-      depth: { type: 'number', default: 5, description: 'Crawling depth for katana' }
+      timeout: { type: 'number', default: 1800, description: 'Optional timeout override in seconds (Katana discover jobs and httpx phase; uses system default if not specified)' },
+      depth: { type: 'number', default: 5, description: 'Crawling depth for katana' },
+      httpx_urls_per_job: { type: 'number', default: 100, description: 'Max discovered URLs per httpx worker job (fan-out across nodes)' },
+      katana_timeout: { type: 'number', default: 900, description: 'Per-job timeout in seconds for Katana discover phase (falls back to timeout when omitted)' }
     }
   },
   fuzz_website: {

--- a/src/runner/app/recon_tasks/base.py
+++ b/src/runner/app/recon_tasks/base.py
@@ -79,6 +79,7 @@ class CommandSpec:
     params: Optional[Dict[str, Any]] = None
     batch_group: Optional[int] = None  # For interleaved spawning (e.g. resolve_ip_cidr)
     waf_targets: Optional[List[str]] = None  # Raw chunk inputs for node block union (HTTP heavy tasks)
+    required_nodes: Optional[List[str]] = None  # Pin job to node(s); spread httpx after WAF exclusions
 
 
 class TaskParameterManager:

--- a/src/runner/app/recon_tasks/crawl_website.py
+++ b/src/runner/app/recon_tasks/crawl_website.py
@@ -1,8 +1,9 @@
 import json
 import logging
+import shlex
 from typing import Dict, List, Any, Optional, Iterator, Union
 import base64
-from .base import Task, AssetType
+from .base import Task, AssetType, CommandSpec
 from models.assets import Url
 from utils import (
     parse_url, 
@@ -46,7 +47,7 @@ class CrawlWebsite(Task):
                 
                 # Join URLs with here document for proper newlines
                 urls_text = '\n'.join(urls_to_process)
-                command = f"cat << 'EOF' | python3 crawl_website.py --depth {depth}"
+                command = f"cat << 'EOF' | python3 crawl_website.py --mode full --depth {depth}"
                 if params.get("timeout", None) is not None:
                     command += f" --timeout {params.get('timeout')}"
                 command += f"\n{urls_text}\nEOF"
@@ -55,7 +56,209 @@ class CrawlWebsite(Task):
         except Exception as e:
             logger.error(f"Error generating command: {e}")
             return ""
-    
+
+    @staticmethod
+    def _job_output_text(output: Any) -> str:
+        """Extract worker stdout string from NATS job payload."""
+        if output is None:
+            return ""
+        if isinstance(output, dict):
+            o = output.get("output")
+            if isinstance(o, str):
+                return o
+            if o is not None:
+                try:
+                    return json.dumps(o)
+                except (TypeError, ValueError):
+                    return str(o)
+            return ""
+        if isinstance(output, str):
+            return output
+        return str(output)
+
+    def _discover_command_line(self, seed: str, params: Dict[str, Any]) -> str:
+        depth = int(params.get("depth", 5))
+        parts = [
+            "cat << 'EOF' | python3 crawl_website.py --mode discover",
+            f"--depth {depth}",
+        ]
+        tdisc = params.get("katana_timeout")
+        if tdisc is None:
+            tdisc = params.get("timeout")
+        if tdisc is not None:
+            parts.append(f"--timeout {int(tdisc)}")
+        return " ".join(parts) + f"\n{seed}\nEOF"
+
+    def _probe_command_line(self, seed: str, url_lines: List[str], params: Dict[str, Any]) -> str:
+        depth = int(params.get("depth", 5))
+        parts = [
+            "cat << 'EOF' | python3 crawl_website.py --mode probe",
+            f"--depth {depth}",
+            f"--seed {shlex.quote(seed)}",
+        ]
+        if params.get("timeout") is not None:
+            parts.append(f"--timeout {int(params['timeout'])}")
+        header = " ".join(parts)
+        body = "\n".join(url_lines)
+        return f"{header}\n{body}\nEOF"
+
+    def _merge_discovered_urls(
+        self,
+        batch_jobs_outputs: Any,
+        seeds: List[str],
+    ) -> Dict[str, List[str]]:
+        """Merge Katana discover JSON from each job; ensure seed URL is probed."""
+        by_seed: Dict[str, List[str]] = {s: [] for s in seeds}
+        seed_by_cmp = {normalize_url_for_comparison(s): s for s in seeds if s}
+
+        for _tid, payload in (batch_jobs_outputs or {}).items():
+            text = self._job_output_text(payload)
+            if not text.strip():
+                continue
+            try:
+                data = json.loads(text)
+            except json.JSONDecodeError:
+                logger.warning("Katana discover output was not valid JSON")
+                continue
+            for key, info in (data.get("urls") or {}).items():
+                if not isinstance(info, dict):
+                    continue
+                disc = info.get("discovered") or []
+                if not isinstance(disc, list):
+                    continue
+                sk = seed_by_cmp.get(normalize_url_for_comparison(str(key)))
+                if sk is None and key in by_seed:
+                    sk = str(key)
+                if sk is None:
+                    continue
+                merged_list = by_seed.setdefault(sk, [])
+                seen_local = set(merged_list)
+                for u in disc:
+                    if isinstance(u, str) and u.strip() and u.strip() not in seen_local:
+                        seen_local.add(u.strip())
+                        merged_list.append(u.strip())
+
+        for seed in seeds:
+            lst = by_seed.setdefault(seed, [])
+            if seed not in lst:
+                lst.insert(0, seed)
+        return by_seed
+
+    def _shard_list(self, items: List[str], shard_size: int) -> List[List[str]]:
+        if shard_size < 1:
+            shard_size = 1
+        return [items[i : i + shard_size] for i in range(0, len(items), shard_size)]
+
+    async def generate_commands(
+        self,
+        input_data: List[Any],
+        params: Dict[str, Any],
+        context: Dict[str, Any],
+    ) -> List[CommandSpec]:
+        """
+        Katana discover jobs (await), merge URLs, then return httpx probe CommandSpecs
+        sharded across worker nodes (required_nodes round-robin among WAF-allowed nodes).
+        """
+        from services import waf_detection
+
+        if not input_data:
+            return []
+
+        p = params or {}
+        jm = context.get("job_manager")
+        if not jm:
+            logger.error("crawl_website generate_commands: no job_manager in context")
+            return []
+
+        seeds = get_valid_urls(
+            input_data if isinstance(input_data, list) else [input_data]
+        )
+        if not seeds:
+            return []
+
+        self.job_manager = jm
+        waf_rep = context.get("waf_reputation")
+
+        katana_cmds = [self._discover_command_line(s, p) for s in seeds]
+        kat_per_job: List[Dict[str, Any]] = []
+        for s in seeds:
+            pe: Dict[str, Any] = {}
+            if waf_detection.is_waf_detection_enabled() and waf_rep is not None:
+                pe["excluded_nodes"] = waf_rep.union_excluded_sorted([str(s)])
+                pe["waf_targets"] = [str(s)]
+            kat_per_job.append(pe)
+
+        kat_job_timeout = int(
+            p.get("katana_timeout") or p.get("timeout") or 900
+        )
+        batch_result = await jm.spawn_batch(
+            task_name=self.name,
+            commands=katana_cmds,
+            batch_size=20,
+            timeout=kat_job_timeout,
+            process_incrementally=False,
+            result_processor=None,
+            step_name=context.get("step_name", "crawl-discover"),
+            per_job_extra=kat_per_job if any(kat_per_job) else None,
+        )
+
+        def _katana_wait_timeout() -> float:
+            return float(kat_job_timeout) * max(1, len(katana_cmds))
+
+        await jm.wait_for_batch(
+            batch_result,
+            timeout=_katana_wait_timeout(),
+        )
+
+        outputs = jm.get_job_outputs(batch_result)
+        merged = self._merge_discovered_urls(outputs, seeds)
+        jm.cleanup_batch(batch_result)
+
+        try:
+            jm._ensure_k8s_service()
+        except Exception:
+            pass
+        k8s = getattr(jm, "k8s_service", None)
+        worker_nodes: List[str] = k8s.list_worker_nodes() if k8s else []
+
+        httpx_urls_per_job = int(p.get("httpx_urls_per_job", 100))
+        specs: List[CommandSpec] = []
+        job_idx = 0
+
+        for seed in seeds:
+            urls = merged.get(seed) or [seed]
+            for chunk in self._shard_list(urls, httpx_urls_per_job):
+                cmd = self._probe_command_line(seed, chunk, p)
+                wt = [str(seed)]
+                req_nodes: Optional[List[str]] = None
+                if worker_nodes:
+                    ex_set: set[str] = set()
+                    if waf_detection.is_waf_detection_enabled() and waf_rep is not None:
+                        ex_set = set(waf_rep.union_excluded_sorted([str(seed)]))
+                    allowed = [n for n in worker_nodes if n not in ex_set]
+                    if not allowed:
+                        allowed = list(worker_nodes)
+                    pick = allowed[job_idx % len(allowed)]
+                    req_nodes = [pick]
+                job_idx += 1
+
+                specs.append(
+                    CommandSpec(
+                        task_name=self.name,
+                        command=cmd,
+                        params=p,
+                        waf_targets=wt,
+                        required_nodes=req_nodes,
+                    )
+                )
+
+        logger.info(
+            "crawl_website: discover %s seed(s) -> %s httpx shard job(s)",
+            len(seeds),
+            len(specs),
+        )
+        return specs
+
     def _resolve_dns_safely(self, hostname: str, timeout: int = 5) -> List[str]:
         """
         Safely resolve DNS for a hostname with proper error handling and timeout.

--- a/src/runner/app/task_executor.py
+++ b/src/runner/app/task_executor.py
@@ -603,6 +603,11 @@ class TaskExecutor:
             # Unified execution path: all tasks use generate_commands
             proxy_enabled = task_def.use_proxy and hasattr(task_instance, 'supports_proxy') and task_instance.supports_proxy()
             if proxy_enabled:
+                if task_def.name == "crawl_website":
+                    logger.info(
+                        "crawl_website with use_proxy: using single-job full crawl on worker "
+                        "(phased Katana + sharded httpx fan-out is disabled when proxying)"
+                    )
                 logger.info(f"Using WorkerJobManager with proxy for task {task_def.name}")
                 processed_assets = await self._execute_task_with_job_manager(
                     task_def, task_instance, program_name, input_data, step_num, step_name, progressive_assets_sent_count
@@ -3689,6 +3694,7 @@ class TaskExecutor:
                 "task_def": task_def,
                 "task_queue_client": self.task_queue_client,
                 "job_manager": self.job_manager,
+                "waf_reputation": self.waf_reputation,
             }
 
             # 1. Generate commands (all tasks implement this)
@@ -3781,18 +3787,21 @@ class TaskExecutor:
                 )
 
                 per_job_extra: Optional[List[Dict[str, Any]]] = None
-                if waf_detection.is_waf_detection_enabled():
-                    per_job_extra = []
-                    for spec in specs:
+                per_spec_extra: List[Dict[str, Any]] = []
+                for spec in specs:
+                    pe: Dict[str, Any] = {}
+                    if waf_detection.is_waf_detection_enabled():
                         wt = spec.waf_targets or []
-                        per_job_extra.append(
-                            {
-                                "excluded_nodes": self.waf_reputation.union_excluded_sorted(
-                                    [str(x) for x in wt]
-                                ),
-                                "waf_targets": [str(x) for x in wt],
-                            }
+                        pe["excluded_nodes"] = self.waf_reputation.union_excluded_sorted(
+                            [str(x) for x in wt]
                         )
+                        pe["waf_targets"] = [str(x) for x in wt]
+                    rn = getattr(spec, "required_nodes", None)
+                    if rn:
+                        pe["required_nodes"] = list(rn)
+                    per_spec_extra.append(pe)
+                if any(per_spec_extra):
+                    per_job_extra = per_spec_extra
 
                 batch_result = await self.job_manager.spawn_batch(
                     task_name=task_name,

--- a/src/runner/tests/recon_tasks/test_base.py
+++ b/src/runner/tests/recon_tasks/test_base.py
@@ -66,6 +66,8 @@ def test_command_spec_defaults() -> None:
     spec = CommandSpec(task_name="t", command="echo x")
     assert spec.params is None
     assert spec.batch_group is None
+    assert spec.waf_targets is None
+    assert spec.required_nodes is None
 
 
 def test_normalize_output_for_parsing_string_passthrough(task: _DummyTask) -> None:

--- a/src/runner/tests/recon_tasks/test_crawl_website.py
+++ b/src/runner/tests/recon_tasks/test_crawl_website.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import base64
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -24,8 +24,9 @@ def test_get_timestamp_hash_is_reversible(task: CrawlWebsite) -> None:
     assert "https://example.com" in decoded
 
 
-def test_get_command_uses_depth_and_timeout(task: CrawlWebsite) -> None:
+def test_get_command_uses_full_mode_depth_and_timeout(task: CrawlWebsite) -> None:
     cmd = task.get_command(["https://example.com"], params={"depth": 3, "timeout": 60})
+    assert "--mode full" in cmd
     assert "--depth 3" in cmd
     assert "--timeout 60" in cmd
     assert "https://example.com:443" in cmd
@@ -33,6 +34,7 @@ def test_get_command_uses_depth_and_timeout(task: CrawlWebsite) -> None:
 
 def test_get_command_default_depth_without_timeout(task: CrawlWebsite) -> None:
     cmd = task.get_command(["https://example.com"], params={})
+    assert "--mode full" in cmd
     assert "--depth 5" in cmd
     assert "--timeout" not in cmd
 
@@ -133,3 +135,47 @@ def test_parse_output_empty_returns_empty(task: CrawlWebsite) -> None:
 
 def test_parse_output_invalid_json_returns_empty(task: CrawlWebsite) -> None:
     assert task.parse_output("not json {{{") == {AssetType.URL: []}
+
+
+@pytest.mark.asyncio
+async def test_generate_commands_phased_discover_then_probe_shards(task: CrawlWebsite) -> None:
+    seed = "https://example.com"
+    discover_txt = json.dumps(
+        {
+            "urls": {
+                "https://example.com:443": {
+                    "discovered": [
+                        "https://example.com:443/",
+                        "https://example.com:443/a",
+                        "https://example.com:443/b",
+                    ]
+                }
+            }
+        }
+    )
+    fake_batch = MagicMock()
+    jm = MagicMock()
+    jm.spawn_batch = AsyncMock(return_value=fake_batch)
+    jm.wait_for_batch = AsyncMock()
+    jm.get_job_outputs = MagicMock(return_value={"t1": {"output": discover_txt}})
+    jm.cleanup_batch = MagicMock()
+    jm._ensure_k8s_service = MagicMock()
+    jm.k8s_service = MagicMock()
+    jm.k8s_service.list_worker_nodes.return_value = ["n1", "n2"]
+
+    specs = await task.generate_commands(
+        [seed],
+        {"httpx_urls_per_job": 1, "depth": 2, "katana_timeout": 60},
+        {"job_manager": jm, "waf_reputation": None, "step_name": "step"},
+    )
+    assert len(specs) == 4
+    assert all("python3 crawl_website.py --mode probe" in s.command for s in specs)
+    assert jm.spawn_batch.call_count == 1
+    discover_call = jm.spawn_batch.call_args_list[0]
+    assert discover_call[1]["commands"][0].startswith(
+        "cat << 'EOF' | python3 crawl_website.py --mode discover"
+    )
+    assert specs[0].required_nodes == ["n1"]
+    assert specs[1].required_nodes == ["n2"]
+    assert specs[2].required_nodes == ["n1"]
+    assert specs[3].required_nodes == ["n2"]

--- a/src/worker/app/crawl_website.py
+++ b/src/worker/app/crawl_website.py
@@ -1,6 +1,7 @@
 import sys
 import json
 import logging
+from typing import List
 import subprocess
 import os
 import argparse
@@ -144,16 +145,15 @@ def run_katana(target: str, depth: int = 5, timeout: int = 0):
     return subprocess.run(command, capture_output=True, text=True)
 
 def run_httpx(urls: str):
-    # Split the input by newlines to get individual URLs
-    url_list = urls.strip().split("\n")
+    # Split the input by newlines to get individual URLs (newline-separated text)
+    url_list = [x.strip() for x in urls.strip().split("\n") if x.strip()]
     
     # Create a temporary file to store URLs
     tmp_filename = None
     try:
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp:
             for url in url_list:
-                if url.strip():
-                    tmp.write(f"{url.strip()}\n")
+                tmp.write(f"{url}\n")
             tmp_filename = tmp.name
         
         # Create a temporary directory to store the output in /tmp/httpx_output
@@ -362,97 +362,171 @@ def cleanup_old_temp_directories():
         logger.error(f"Error during periodic cleanup: {str(e)}")
 
 
+def _discovered_urls_from_katana_stdout(stdout: str) -> List[str]:
+    seen: set[str] = set()
+    out: List[str] = []
+    for line in (stdout or "").splitlines():
+        u = line.strip()
+        if u and u not in seen:
+            seen.add(u)
+            out.append(u)
+    return out
+
+
+def run_full_crawl_for_target(
+    normalized_url: str, depth: int, timeout: int, results: dict
+) -> None:
+    """Katana + httpx + link extraction for one seed (legacy full mode)."""
+    results["urls"][normalized_url] = {
+        "httpx_output": None,
+        "httpx_error": None,
+        "links": {},
+    }
+    katana_process = run_katana(normalized_url, depth, timeout)
+    if not katana_process.stdout and katana_process.stderr:
+        logger.error(f"Katana error for {normalized_url}: {katana_process.stderr}")
+    elif katana_process.stdout:
+        logger.info(f"Katana found URLs to process for {normalized_url}")
+        logger.info(f"Running httpx against discovered URLs for {normalized_url}...")
+        httpx_process = run_httpx(katana_process.stdout)
+        if httpx_process:
+            logger.info(f"Httpx process completed for {normalized_url}")
+            if httpx_process.stderr:
+                logger.warning(f"Httpx warnings for {normalized_url}: {httpx_process.stderr}")
+                results["urls"][normalized_url]["httpx_error"] = httpx_process.stderr
+            httpx_output = httpx_process.stdout
+            httpx_output_obj = []
+            for line in httpx_output.split("\n"):
+                if line.strip():
+                    try:
+                        httpx_output_obj.append(json.loads(line))
+                    except json.JSONDecodeError:
+                        continue
+                    except Exception as e:
+                        logger.error(f"Error parsing httpx output: {str(e)}")
+                        continue
+            results["urls"][normalized_url]["httpx_output"] = httpx_output_obj
+            logger.info(f"Parsing links for {normalized_url}...")
+            results["urls"][normalized_url]["links"] = parse_links(normalized_url)
+            logger.info(
+                "Extracted links for %s: %s pages with external links",
+                normalized_url,
+                len(results["urls"][normalized_url]["links"]),
+            )
+        else:
+            logger.error(f"Failed to run httpx for {normalized_url}")
+
+
 def main():
-        # Parse command-line arguments
-        parser = argparse.ArgumentParser()
-        parser.add_argument('--depth', type=int, default=5, help='Crawling depth for katana')
-        parser.add_argument('--timeout', type=int, required=False, default=0, help='Timeout for the script')
-        args, unknown = parser.parse_known_args()
-        depth = args.depth
-        timeout = args.timeout
-        logger.info(f"Depth: {depth}, Timeout: {timeout}")
-        # Read and split input URLs
-        input_urls = [url.strip() for url in sys.stdin.readlines() if url.strip()]
-        logger.info(f"Received {len(input_urls)} targets")
-        if not input_urls:
-            logger.error("No targets provided via stdin.")
-            sys.exit(1)
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--mode",
+        choices=("full", "discover", "probe"),
+        default="full",
+        help="full: katana+httpx per seed; discover: katana only; probe: httpx+links for stdin URLs",
+    )
+    parser.add_argument("--seed", type=str, default=None, help="Normalized seed URL (required for probe mode)")
+    parser.add_argument("--depth", type=int, default=5, help="Crawling depth for katana")
+    parser.add_argument("--timeout", type=int, required=False, default=0, help="Timeout for the script")
+    args, unknown = parser.parse_known_args()
+    depth = args.depth
+    timeout = args.timeout
+    mode = args.mode
+    logger.info("Mode: %s, depth: %s, timeout: %s", mode, depth, timeout)
 
-        # Clean up old temporary directories first
-        cleanup_old_temp_directories()
+    input_urls = [url.strip() for url in sys.stdin.readlines() if url.strip()]
+    logger.info("Received %s stdin lines", len(input_urls))
 
-        try:
-            # Initialize results structure
-            results = {
-                "urls": {}  # Will store results per URL
+    cleanup_old_temp_directories()
+
+    try:
+        results: dict = {"urls": {}}
+
+        if mode == "probe":
+            if not args.seed:
+                logger.error("probe mode requires --seed")
+                sys.exit(1)
+            is_valid, normalized_seed = is_valid_url(args.seed)
+            if not is_valid:
+                logger.error("Invalid --seed URL: %s", args.seed)
+                sys.exit(1)
+            if not input_urls:
+                logger.error("probe mode requires at least one URL on stdin")
+                sys.exit(1)
+            probe_text = "\n".join(input_urls)
+            results["urls"][normalized_seed] = {
+                "httpx_output": None,
+                "httpx_error": None,
+                "links": {},
             }
-
-            # Process each URL
+            httpx_process = run_httpx(probe_text)
+            if httpx_process:
+                if httpx_process.stderr:
+                    logger.warning("Httpx stderr: %s", httpx_process.stderr)
+                    results["urls"][normalized_seed]["httpx_error"] = httpx_process.stderr
+                httpx_output_obj = []
+                for line in (httpx_process.stdout or "").split("\n"):
+                    if line.strip():
+                        try:
+                            httpx_output_obj.append(json.loads(line))
+                        except json.JSONDecodeError:
+                            continue
+                        except Exception as e:
+                            logger.error("Error parsing httpx output: %s", e)
+                            continue
+                results["urls"][normalized_seed]["httpx_output"] = httpx_output_obj
+                results["urls"][normalized_seed]["links"] = parse_links(normalized_seed)
+            else:
+                logger.error("Failed to run httpx in probe mode")
+        elif mode == "discover":
+            if not input_urls:
+                logger.error("No targets provided via stdin.")
+                sys.exit(1)
             for target in input_urls:
-                # Validate URL
                 is_valid, normalized_url = is_valid_url(target)
                 if not is_valid:
-                    logger.error(f"Invalid target URL: {target}")
+                    logger.error("Invalid target URL: %s", target)
                     results["urls"][target] = {
                         "error": "Invalid URL format",
-                        "normalized_url": None
+                        "normalized_url": None,
+                        "discovered": [],
                     }
                     continue
-
-                logger.info(f"Crawling target: {normalized_url}")
-
-                # Per-seed envelope: raw httpx stdout + extracted_links map (no Katana artifact).
-                results["urls"][normalized_url] = {
-                    "httpx_output": None,
-                    "httpx_error": None,
-                    "links": {},
-                }
-
-                # Run katana to crawl the target (feeds httpx only; not serialized to runner).
+                results["urls"][normalized_url] = {"discovered": [], "katana_stderr": None}
                 katana_process = run_katana(normalized_url, depth, timeout)
+                if katana_process.stderr:
+                    results["urls"][normalized_url]["katana_stderr"] = katana_process.stderr
                 if not katana_process.stdout and katana_process.stderr:
-                    logger.error(f"Katana error for {normalized_url}: {katana_process.stderr}")
-                elif katana_process.stdout:
-                    logger.info(f"Katana found URLs to process for {normalized_url}")
+                    logger.error("Katana error for %s: %s", normalized_url, katana_process.stderr)
+                else:
+                    discovered = _discovered_urls_from_katana_stdout(katana_process.stdout or "")
+                    if normalized_url not in discovered:
+                        discovered.insert(0, normalized_url)
+                    results["urls"][normalized_url]["discovered"] = discovered
+                    logger.info("Discover: %s URLs for %s", len(discovered), normalized_url)
+        else:
+            # full
+            if not input_urls:
+                logger.error("No targets provided via stdin.")
+                sys.exit(1)
+            for target in input_urls:
+                is_valid, normalized_url = is_valid_url(target)
+                if not is_valid:
+                    logger.error("Invalid target URL: %s", target)
+                    results["urls"][target] = {
+                        "error": "Invalid URL format",
+                        "normalized_url": None,
+                    }
+                    continue
+                logger.info("Crawling target: %s", normalized_url)
+                run_full_crawl_for_target(normalized_url, depth, timeout, results)
 
-                    # Run httpx against the discovered URLs
-                    logger.info(f"Running httpx against discovered URLs for {normalized_url}...")
-                    httpx_process = run_httpx(katana_process.stdout)
+    finally:
+        delete_temp_output()
 
-                    if httpx_process:
-                        logger.info(f"Httpx process completed for {normalized_url}")
-                        if httpx_process.stderr:
-                            logger.warning(f"Httpx warnings for {normalized_url}: {httpx_process.stderr}")
-                            results["urls"][normalized_url]["httpx_error"] = httpx_process.stderr
+    logger.info("All tasks completed, outputting results")
+    print(json.dumps(results))
 
-                        # Store httpx output as-is
-                        httpx_output = httpx_process.stdout
-                        httpx_output_obj = []
-                        for line in httpx_output.split("\n"):
-                            if line.strip():
-                                try:
-                                    httpx_output_obj.append(json.loads(line))
-                                except json.JSONDecodeError:
-                                    continue
-                                except Exception as e:
-                                    logger.error(f"Error parsing httpx output: {str(e)}")
-                                    continue
-                        results["urls"][normalized_url]["httpx_output"] = httpx_output_obj
-                        # After httpx has run, parse the links from the responses
-                        logger.info(f"Parsing links for {normalized_url}...")
-                        extracted_links = parse_links(normalized_url)
-
-                        results["urls"][normalized_url]["links"] = extracted_links
-                        logger.info(f"Extracted links for {normalized_url}: {len(extracted_links)} pages with external links")
-                    else:
-                        logger.error(f"Failed to run httpx for {normalized_url}")
-
-        finally:
-            # Final cleanup of temporary output
-            delete_temp_output()
-
-        logger.info("All tasks completed, outputting results")
-        print(json.dumps(results))
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Runner awaits discover jobs, merges Katana URL lists, then runs httpx in sharded worker jobs with round-robin node pinning among WAF-allowed nodes. Worker adds discover/probe/full CLI modes; FireProx still uses single-job full mode. New task params: httpx_urls_per_job, katana_timeout.